### PR TITLE
rename sandbox.yaml to ksctl.yaml

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -188,7 +188,7 @@ func TestUpdateUserSignupLacksPermissions(t *testing.T) {
 	}, "updated")
 
 	// then
-	require.EqualError(t, err, "sandbox command failed: the token in your sandbox.yaml file is missing")
+	require.EqualError(t, err, "sandbox command failed: the token in your ksctl.yaml file is missing")
 	AssertUserSignupSpec(t, fakeClient, userSignup)
 }
 

--- a/pkg/cmd/adm/generate_cli_configs.go
+++ b/pkg/cmd/adm/generate_cli_configs.go
@@ -36,8 +36,8 @@ func NewGenerateCliConfigsCmd() *cobra.Command {
 	f := generateFlags{}
 	command := &cobra.Command{
 		Use:   "generate-cli-configs --sandbox-config=<path-to-sandbox-config-file>",
-		Short: "Generate sandbox.yaml files",
-		Long:  `Generate sandbox.yaml files, that is used by sandbox-cli, for every ServiceAccount defined in the given sandbox-config.yaml file`,
+		Short: "Generate ksctl.yaml files",
+		Long:  `Generate ksctl.yaml files, that is used by sandbox-cli, for every ServiceAccount defined in the given sandbox-config.yaml file`,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			term := ioutils.NewTerminal(cmd.InOrStdin, cmd.OutOrStdout)
@@ -49,7 +49,7 @@ func NewGenerateCliConfigsCmd() *cobra.Command {
 	command.Flags().BoolVarP(&f.dev, "dev", "d", false, "If running in a dev cluster")
 
 	configDirPath := fmt.Sprintf("%s/src/github.com/kubesaw/ksctl/out/config", os.Getenv("GOPATH"))
-	command.Flags().StringVarP(&f.outDir, "out-dir", "o", configDirPath, "Directory where generated sandbox.yaml files should be stored")
+	command.Flags().StringVarP(&f.outDir, "out-dir", "o", configDirPath, "Directory where generated ksctl.yaml files should be stored")
 
 	defaultKubeconfigPath := ""
 	if home := homedir.HomeDir(); home != "" {
@@ -94,7 +94,7 @@ func generate(term ioutils.Terminal, flags generateFlags, newClient NewClientFro
 		kubeconfigPaths:  flags.kubeconfigs,
 	}
 
-	// sandboxUserConfigsPerName contains all sandboxUserConfig objects that will be marshalled to sandbox.yaml files
+	// sandboxUserConfigsPerName contains all sandboxUserConfig objects that will be marshalled to ksctl.yaml files
 	sandboxUserConfigsPerName := map[string]configuration.SandboxUserConfig{}
 
 	// use host API either from the sandbox-config.yaml or from kubeconfig if --dev flag was used
@@ -148,11 +148,11 @@ func writeSandboxUserConfigs(term ioutils.Terminal, configDirPath string, sandbo
 		if err != nil {
 			return err
 		}
-		path := pathDir + "/sandbox.yaml"
+		path := pathDir + "/ksctl.yaml"
 		if err := os.WriteFile(path, content, 0600); err != nil {
 			return err
 		}
-		term.Printlnf("sandbox.yaml file for %s was stored in %s", name, path)
+		term.Printlnf("ksctl.yaml file for %s was stored in %s", name, path)
 	}
 	return nil
 }
@@ -169,7 +169,7 @@ type generateContext struct {
 type tokenPerSA map[string]string
 
 func generateForCluster(ctx *generateContext, clusterType configuration.ClusterType, clusterName string, clusterSpec assets.ClusterConfig, sandboxUserConfigsPerName map[string]configuration.SandboxUserConfig) error {
-	ctx.PrintContextSeparatorf("Generating the content of the sandbox.yaml files for %s cluster running at %s", clusterName, clusterSpec.API)
+	ctx.PrintContextSeparatorf("Generating the content of the ksctl.yaml files for %s cluster running at %s", clusterName, clusterSpec.API)
 
 	// find config we can build client for the cluster from
 	externalClient, err := buildClientFromKubeconfigFiles(ctx, clusterSpec.API, ctx.kubeconfigPaths)

--- a/pkg/cmd/adm/generate_cli_configs_test.go
+++ b/pkg/cmd/adm/generate_cli_configs_test.go
@@ -237,7 +237,7 @@ func verifySandboxUserConfigFiles(t *testing.T, tempDir string, clusterAssertion
 		require.NoError(t, err)
 
 		assert.Len(t, userDirInfo, 1)
-		assert.Equal(t, "sandbox.yaml", userDirInfo[0].Name())
+		assert.Equal(t, "ksctl.yaml", userDirInfo[0].Name())
 		content, err := os.ReadFile(path.Join(tempDir, userDir.Name(), userDirInfo[0].Name()))
 		require.NoError(t, err)
 

--- a/pkg/cmd/adm/unregister_member_test.go
+++ b/pkg/cmd/adm/unregister_member_test.go
@@ -96,7 +96,7 @@ func TestUnregisterMemberWhenUnknownClusterName(t *testing.T) {
 
 	// then
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "the provided cluster-name 'some' is not present in your sandbox.yaml file.")
+	assert.Contains(t, err.Error(), "the provided cluster-name 'some' is not present in your ksctl.yaml file.")
 	AssertToolchainClusterSpec(t, fakeClient, toolchainCluster)
 	assert.NotContains(t, term.Output(), "!!!  DANGER ZONE  !!!")
 	assert.NotContains(t, term.Output(), "THIS COMMAND WILL CAUSE UNREGISTER MEMBER CLUSTER FORM HOST CLUSTER. MAKE SURE THERE IS NO USERS LEFT IN THE MEMBER CLUSTER BEFORE UNREGISTERING IT")
@@ -118,6 +118,6 @@ func TestUnregisterMemberLacksPermissions(t *testing.T) {
 	err := UnregisterMemberCluster(ctx, "member1")
 
 	// then
-	require.EqualError(t, err, "sandbox command failed: the token in your sandbox.yaml file is missing")
+	require.EqualError(t, err, "sandbox command failed: the token in your ksctl.yaml file is missing")
 	AssertToolchainClusterSpec(t, fakeClient, toolchainCluster)
 }

--- a/pkg/cmd/approve_test.go
+++ b/pkg/cmd/approve_test.go
@@ -271,7 +271,7 @@ func TestApprove(t *testing.T) {
 
 			// then
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "the provided cluster-name 'non-existent-member' is not present in your sandbox.yaml file")
+			assert.Contains(t, err.Error(), "the provided cluster-name 'non-existent-member' is not present in your ksctl.yaml file")
 		})
 	})
 }

--- a/pkg/cmd/ban_test.go
+++ b/pkg/cmd/ban_test.go
@@ -224,6 +224,6 @@ func TestCreateBannedUserLacksPermissions(t *testing.T) {
 	})
 
 	// then
-	require.EqualError(t, err, "sandbox command failed: the token in your sandbox.yaml file is missing")
+	require.EqualError(t, err, "sandbox command failed: the token in your ksctl.yaml file is missing")
 	AssertUserSignupSpec(t, fakeClient, userSignup)
 }

--- a/pkg/cmd/delete_test.go
+++ b/pkg/cmd/delete_test.go
@@ -89,7 +89,7 @@ func TestDeleteLacksPermissions(t *testing.T) {
 	err := cmd.Delete(ctx, userSignup.Name)
 
 	// then
-	require.EqualError(t, err, "sandbox command failed: the token in your sandbox.yaml file is missing")
+	require.EqualError(t, err, "sandbox command failed: the token in your ksctl.yaml file is missing")
 	AssertUserSignupSpec(t, fakeClient, userSignup)
 }
 

--- a/pkg/cmd/retarget_test.go
+++ b/pkg/cmd/retarget_test.go
@@ -83,7 +83,7 @@ func TestRetarget(t *testing.T) {
 
 			// then
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "the provided cluster-name 'non-existent-member' is not present in your sandbox.yaml file")
+			assert.Contains(t, err.Error(), "the provided cluster-name 'non-existent-member' is not present in your ksctl.yaml file")
 		})
 
 		t.Run("setting target cluster failed", func(t *testing.T) {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -34,7 +34,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&configuration.ConfigFileFlag, "config", "", "config file (default is $HOME/.sandbox.yaml)")
+	rootCmd.PersistentFlags().StringVar(&configuration.ConfigFileFlag, "config", "", "config file (default is $HOME/.ksctl.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&configuration.Verbose, "verbose", "v", false, "print extra info/debug messages")
 
 	// commands with go runtime client

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -135,7 +135,7 @@ func TestLoadClusterConfig(t *testing.T) {
 					cfg, err := configuration.LoadClusterConfig(term, clusterName)
 
 					// then
-					require.EqualError(t, err, "sandbox command failed: the token in your sandbox.yaml file is missing")
+					require.EqualError(t, err, "sandbox command failed: the token in your ksctl.yaml file is missing")
 					assert.Empty(t, cfg.Token)
 				})
 			}
@@ -186,7 +186,7 @@ func TestLoadClusterConfig(t *testing.T) {
 
 				// then
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "the provided cluster-name 'dummy' is not present in your sandbox.yaml file. The available cluster names are")
+				assert.Contains(t, err.Error(), "the provided cluster-name 'dummy' is not present in your ksctl.yaml file. The available cluster names are")
 			})
 
 			for _, clusterConfigParam := range []ClusterDefinitionWithName{Host(), Member()} {
@@ -223,7 +223,7 @@ func TestLoadingClusterConfigWithNonexistentClusterName(t *testing.T) {
 
 	// then
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "the provided cluster-name 'dummy' is not present in your sandbox.yaml file. The available cluster names are")
+	assert.Contains(t, err.Error(), "the provided cluster-name 'dummy' is not present in your ksctl.yaml file. The available cluster names are")
 	assert.Contains(t, err.Error(), "host")
 	assert.Contains(t, err.Error(), "member-1")
 	assert.Empty(t, cfg.SandboxNamespace)


### PR DESCRIPTION
rename all occurrences of `sandbox.yaml` to `ksctl.yaml`, still supporting the old default location `~/.sandbox.yaml` mark marking it as deprecated.