### PR TITLE
replace `CommandContext` param with `RestartOptions` type

### DIFF
--- a/pkg/cmd/adm/unregister_member.go
+++ b/pkg/cmd/adm/unregister_member.go
@@ -62,5 +62,5 @@ func UnregisterMemberCluster(ctx *clicontext.CommandContext, clusterName string)
 	}
 	ctx.Printlnf("\nThe deletion of the Toolchain member cluster from the Host cluster has been triggered")
 
-	return restartHostOperator(ctx, hostClusterClient, hostClusterConfig)
+	return restartHostOperator(ctx.Context, ctx.Terminal, hostClusterClient, hostClusterConfig)
 }


### PR DESCRIPTION
inspired by the `GetOptions` type in the [kubectl get command](https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/get/get.go#L56-L86),
mostly because `CommandContext` is confusing (I know, I contributed to it!)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
