### PR TITLE
rename most of the sandbox vars, params, and references

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -114,7 +114,7 @@ func PatchUserSignup(ctx *clicontext.CommandContext, name string, changeUserSign
 	if err != nil {
 		return err
 	}
-	userSignup, err := GetUserSignup(cl, cfg.KubeSawNamespace, name)
+	userSignup, err := GetUserSignup(cl, cfg.OperatorNamespace, name)
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func PatchMasterUserRecord(ctx *clicontext.CommandContext, name string, changeMa
 	if err != nil {
 		return err
 	}
-	mur, err := GetMasterUserRecord(cl, cfg.KubeSawNamespace, name)
+	mur, err := GetMasterUserRecord(cl, cfg.OperatorNamespace, name)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func PatchSpace(ctx *clicontext.CommandContext, name string, changeSpace func(*t
 	if err != nil {
 		return err
 	}
-	space, err := GetSpace(cl, cfg.KubeSawNamespace, name)
+	space, err := GetSpace(cl, cfg.OperatorNamespace, name)
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func ListSpaceBindings(cl runtimeclient.Client, namespace string, opts ...SpaceB
 
 func GetNSTemplateTier(cfg configuration.ClusterConfig, cl runtimeclient.Client, name string) (*toolchainv1alpha1.NSTemplateTier, error) {
 	namespacedName := types.NamespacedName{
-		Namespace: cfg.KubeSawNamespace,
+		Namespace: cfg.OperatorNamespace,
 		Name:      name,
 	}
 	obj := &toolchainv1alpha1.NSTemplateTier{}
@@ -256,7 +256,7 @@ func GetNSTemplateTier(cfg configuration.ClusterConfig, cl runtimeclient.Client,
 
 func GetUserTier(cfg configuration.ClusterConfig, cl runtimeclient.Client, name string) (*toolchainv1alpha1.UserTier, error) {
 	namespacedName := types.NamespacedName{
-		Namespace: cfg.KubeSawNamespace,
+		Namespace: cfg.OperatorNamespace,
 		Name:      name,
 	}
 	obj := &toolchainv1alpha1.UserTier{}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -114,7 +114,7 @@ func PatchUserSignup(ctx *clicontext.CommandContext, name string, changeUserSign
 	if err != nil {
 		return err
 	}
-	userSignup, err := GetUserSignup(cl, cfg.SandboxNamespace, name)
+	userSignup, err := GetUserSignup(cl, cfg.KubeSawNamespace, name)
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func PatchMasterUserRecord(ctx *clicontext.CommandContext, name string, changeMa
 	if err != nil {
 		return err
 	}
-	mur, err := GetMasterUserRecord(cl, cfg.SandboxNamespace, name)
+	mur, err := GetMasterUserRecord(cl, cfg.KubeSawNamespace, name)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func PatchSpace(ctx *clicontext.CommandContext, name string, changeSpace func(*t
 	if err != nil {
 		return err
 	}
-	space, err := GetSpace(cl, cfg.SandboxNamespace, name)
+	space, err := GetSpace(cl, cfg.KubeSawNamespace, name)
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func ListSpaceBindings(cl runtimeclient.Client, namespace string, opts ...SpaceB
 
 func GetNSTemplateTier(cfg configuration.ClusterConfig, cl runtimeclient.Client, name string) (*toolchainv1alpha1.NSTemplateTier, error) {
 	namespacedName := types.NamespacedName{
-		Namespace: cfg.SandboxNamespace,
+		Namespace: cfg.KubeSawNamespace,
 		Name:      name,
 	}
 	obj := &toolchainv1alpha1.NSTemplateTier{}
@@ -256,7 +256,7 @@ func GetNSTemplateTier(cfg configuration.ClusterConfig, cl runtimeclient.Client,
 
 func GetUserTier(cfg configuration.ClusterConfig, cl runtimeclient.Client, name string) (*toolchainv1alpha1.UserTier, error) {
 	namespacedName := types.NamespacedName{
-		Namespace: cfg.SandboxNamespace,
+		Namespace: cfg.KubeSawNamespace,
 		Name:      name,
 	}
 	obj := &toolchainv1alpha1.UserTier{}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -188,7 +188,7 @@ func TestUpdateUserSignupLacksPermissions(t *testing.T) {
 	}, "updated")
 
 	// then
-	require.EqualError(t, err, "sandbox command failed: the token in your ksctl.yaml file is missing")
+	require.EqualError(t, err, "ksctl command failed: the token in your ksctl.yaml file is missing")
 	AssertUserSignupSpec(t, fakeClient, userSignup)
 }
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -26,14 +26,14 @@ import (
 func TestNewClientOK(t *testing.T) {
 	// given
 	t.Cleanup(gock.OffAll)
-	gock.New("https://example.com").
+	gock.New("http://example.com").
 		Get("api").
 		Persist().
 		Reply(200).
 		BodyString("{}")
 
 	// when
-	cl, err := client.NewClient("cool-token", "https://example.com")
+	cl, err := client.NewClient("cool-token", "http://example.com")
 
 	// then
 	require.NoError(t, err)

--- a/pkg/client/sandbox_config_file.go
+++ b/pkg/client/sandbox_config_file.go
@@ -5,7 +5,7 @@ import (
 	"path"
 )
 
-func EnsureSandboxCliConfigFile() (string, error) {
+func EnsureKsctlConfigFile() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err

--- a/pkg/cmd/add_space_users.go
+++ b/pkg/cmd/add_space_users.go
@@ -55,7 +55,7 @@ func AddSpaceUsers(ctx *clicontext.CommandContext, spaceName, role string, users
 
 	// get Space
 	ctx.Println("Checking space...")
-	space, err := client.GetSpace(cl, cfg.SandboxNamespace, spaceName)
+	space, err := client.GetSpace(cl, cfg.KubeSawNamespace, spaceName)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func AddSpaceUsers(ctx *clicontext.CommandContext, spaceName, role string, users
 	ctx.Println("Checking users...")
 	spaceBindingsToCreate := []*toolchainv1alpha1.SpaceBinding{}
 	for _, murName := range usersToAdd {
-		mur, err := client.GetMasterUserRecord(cl, cfg.SandboxNamespace, murName)
+		mur, err := client.GetMasterUserRecord(cl, cfg.KubeSawNamespace, murName)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/add_space_users.go
+++ b/pkg/cmd/add_space_users.go
@@ -55,7 +55,7 @@ func AddSpaceUsers(ctx *clicontext.CommandContext, spaceName, role string, users
 
 	// get Space
 	ctx.Println("Checking space...")
-	space, err := client.GetSpace(cl, cfg.KubeSawNamespace, spaceName)
+	space, err := client.GetSpace(cl, cfg.OperatorNamespace, spaceName)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func AddSpaceUsers(ctx *clicontext.CommandContext, spaceName, role string, users
 	ctx.Println("Checking users...")
 	spaceBindingsToCreate := []*toolchainv1alpha1.SpaceBinding{}
 	for _, murName := range usersToAdd {
-		mur, err := client.GetMasterUserRecord(cl, cfg.KubeSawNamespace, murName)
+		mur, err := client.GetMasterUserRecord(cl, cfg.OperatorNamespace, murName)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/adm/generate_cli_configs.go
+++ b/pkg/cmd/adm/generate_cli_configs.go
@@ -44,7 +44,7 @@ func NewGenerateCliConfigsCmd() *cobra.Command {
 			return generate(term, f, runtimeclient.New, DefaultNewExternalClientFromConfig)
 		},
 	}
-	command.Flags().StringVarP(&f.kubeSawAdminsFile, "kubesaw-admins", "c", "", "Use the given sandbox config file")
+	command.Flags().StringVarP(&f.kubeSawAdminsFile, "kubesaw-admins", "c", "", "Use the given kubesaw-admin file")
 	flags.MustMarkRequired(command, "kubesaw-admins")
 	command.Flags().BoolVarP(&f.dev, "dev", "d", false, "If running in a dev cluster")
 
@@ -94,8 +94,8 @@ func generate(term ioutils.Terminal, flags generateFlags, newClient NewClientFro
 		kubeconfigPaths: flags.kubeconfigs,
 	}
 
-	// sandboxUserConfigsPerName contains all sandboxUserConfig objects that will be marshalled to ksctl.yaml files
-	sandboxUserConfigsPerName := map[string]configuration.SandboxUserConfig{}
+	// ksctlConfigsPerName contains all ksctlConfig objects that will be marshalled to ksctl.yaml files
+	ksctlConfigsPerName := map[string]configuration.KsctlConfig{}
 
 	// use host API either from the kubesaw-admins.yaml or from kubeconfig if --dev flag was used
 	hostSpec := kubeSawAdmins.Clusters.Host
@@ -109,7 +109,7 @@ func generate(term ioutils.Terminal, flags generateFlags, newClient NewClientFro
 	}
 
 	// firstly generate for the host cluster
-	if err := generateForCluster(ctx, configuration.Host, "host", hostSpec, sandboxUserConfigsPerName); err != nil {
+	if err := generateForCluster(ctx, configuration.Host, "host", hostSpec, ksctlConfigsPerName); err != nil {
 		return err
 	}
 
@@ -122,29 +122,29 @@ func generate(term ioutils.Terminal, flags generateFlags, newClient NewClientFro
 			memberSpec.API = hostSpec.API
 		}
 
-		if err := generateForCluster(ctx, configuration.Member, member.Name, memberSpec, sandboxUserConfigsPerName); err != nil {
+		if err := generateForCluster(ctx, configuration.Member, member.Name, memberSpec, ksctlConfigsPerName); err != nil {
 			return err
 		}
 	}
 
-	return writeSandboxUserConfigs(term, flags.outDir, sandboxUserConfigsPerName)
+	return writeKsctlConfigs(term, flags.outDir, ksctlConfigsPerName)
 }
 
 func serverName(API string) string {
 	return strings.Split(strings.Split(API, "api.")[1], ":")[0]
 }
 
-// writeSandboxUserConfigs marshals the given SandboxUserConfig objects and stored them in sandbox-sre/out/config/<name>/ directories
-func writeSandboxUserConfigs(term ioutils.Terminal, configDirPath string, sandboxUserConfigsPerName map[string]configuration.SandboxUserConfig) error {
+// writeKsctlConfigs marshals the given KsctlConfig objects and stored them in sandbox-sre/out/config/<name>/ directories
+func writeKsctlConfigs(term ioutils.Terminal, configDirPath string, ksctlConfigsPerName map[string]configuration.KsctlConfig) error {
 	if err := os.RemoveAll(configDirPath); err != nil {
 		return err
 	}
-	for name, sandboxUserConfig := range sandboxUserConfigsPerName {
+	for name, ksctlConfig := range ksctlConfigsPerName {
 		pathDir := fmt.Sprintf("%s/%s", configDirPath, name)
 		if err := os.MkdirAll(pathDir, 0744); err != nil {
 			return err
 		}
-		content, err := yaml.Marshal(sandboxUserConfig)
+		content, err := yaml.Marshal(ksctlConfig)
 		if err != nil {
 			return err
 		}
@@ -168,7 +168,7 @@ type generateContext struct {
 // contains tokens mapped by SA name
 type tokenPerSA map[string]string
 
-func generateForCluster(ctx *generateContext, clusterType configuration.ClusterType, clusterName string, clusterSpec assets.ClusterConfig, sandboxUserConfigsPerName map[string]configuration.SandboxUserConfig) error {
+func generateForCluster(ctx *generateContext, clusterType configuration.ClusterType, clusterName string, clusterSpec assets.ClusterConfig, ksctlConfigsPerName map[string]configuration.KsctlConfig) error {
 	ctx.PrintContextSeparatorf("Generating the content of the ksctl.yaml files for %s cluster running at %s", clusterName, clusterSpec.API)
 
 	// find config we can build client for the cluster from
@@ -205,7 +205,7 @@ func generateForCluster(ctx *generateContext, clusterType configuration.ClusterT
 		}
 	}
 
-	addToSandboxUserConfigs(clusterDef, clusterName, sandboxUserConfigsPerName, tokenPerSAName)
+	addToKsctlConfigs(clusterDef, clusterName, ksctlConfigsPerName, tokenPerSAName)
 
 	return nil
 }
@@ -253,17 +253,17 @@ func getServiceAccountToken(cl *rest.RESTClient, namespacedName types.Namespaced
 	return result.Status.Token, nil
 }
 
-// addToSandboxUserConfigs adds to sandboxUserConfig objects information about the cluster as well as the SA token
-func addToSandboxUserConfigs(clusterDev configuration.ClusterDefinition, clusterName string, sandboxUserConfigsPerName map[string]configuration.SandboxUserConfig, tokensPerSA tokenPerSA) {
+// addToKsctlConfigs adds to ksctlConfig objects information about the cluster as well as the SA token
+func addToKsctlConfigs(clusterDev configuration.ClusterDefinition, clusterName string, ksctlConfigsPerName map[string]configuration.KsctlConfig, tokensPerSA tokenPerSA) {
 	for name, token := range tokensPerSA {
-		if _, ok := sandboxUserConfigsPerName[name]; !ok {
-			sandboxUserConfigsPerName[name] = configuration.SandboxUserConfig{
+		if _, ok := ksctlConfigsPerName[name]; !ok {
+			ksctlConfigsPerName[name] = configuration.KsctlConfig{
 				Name:                     name,
 				ClusterAccessDefinitions: map[string]configuration.ClusterAccessDefinition{},
 			}
 		}
 		clusterName := utils.KebabToCamelCase(clusterName)
-		sandboxUserConfigsPerName[name].ClusterAccessDefinitions[clusterName] = configuration.ClusterAccessDefinition{
+		ksctlConfigsPerName[name].ClusterAccessDefinitions[clusterName] = configuration.ClusterAccessDefinition{
 			ClusterDefinition: clusterDev,
 			Token:             token,
 		}

--- a/pkg/cmd/adm/generate_cli_configs_test.go
+++ b/pkg/cmd/adm/generate_cli_configs_test.go
@@ -45,7 +45,7 @@ func TestGenerateCliConfigs(t *testing.T) {
 
 	kubeSawAdminsContent, err := yaml.Marshal(kubeSawAdmins)
 	require.NoError(t, err)
-	kubeconfigFiles := createKubeconfigFiles(t, sandboxKubeconfigContent, sandboxKubeconfigContentMember2)
+	kubeconfigFiles := createKubeconfigFiles(t, ksctlKubeconfigContent, ksctlKubeconfigContentMember2)
 
 	setupGockForServiceAccounts(t, HostServerAPI,
 		newServiceAccount("sandbox-sre-host", "john"),
@@ -80,7 +80,7 @@ func TestGenerateCliConfigs(t *testing.T) {
 			// then
 			require.NoError(t, err)
 
-			verifySandboxUserConfigFiles(t, tempDir, hasHost(), hasMember("member1", "member1"), hasMember("member2", "member2"))
+			verifyKsctlConfigFiles(t, tempDir, hasHost(), hasMember("member1", "member1"), hasMember("member2", "member2"))
 		})
 
 		t.Run("when there SAs are defined for host cluster only", func(t *testing.T) {
@@ -108,7 +108,7 @@ func TestGenerateCliConfigs(t *testing.T) {
 			// then
 			require.NoError(t, err)
 
-			verifySandboxUserConfigFiles(t, tempDir, hasHost())
+			verifyKsctlConfigFiles(t, tempDir, hasHost())
 		})
 
 		t.Run("in dev mode", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestGenerateCliConfigs(t *testing.T) {
 			)
 			tempDir, err := os.MkdirTemp("", "sandbox-sre-out-")
 			require.NoError(t, err)
-			kubeconfigFiles := createKubeconfigFiles(t, sandboxKubeconfigContent)
+			kubeconfigFiles := createKubeconfigFiles(t, ksctlKubeconfigContent)
 			flags := generateFlags{kubeconfigs: kubeconfigFiles, kubeSawAdminsFile: configFile, outDir: tempDir, dev: true}
 
 			// when
@@ -128,7 +128,7 @@ func TestGenerateCliConfigs(t *testing.T) {
 			// then
 			require.NoError(t, err)
 
-			verifySandboxUserConfigFiles(t, tempDir, hasHost(), hasMember("member1", "host"), hasMember("member2", "host"))
+			verifyKsctlConfigFiles(t, tempDir, hasHost(), hasMember("member1", "host"), hasMember("member2", "host"))
 		})
 	})
 
@@ -227,7 +227,7 @@ func TestGetServiceAccountToken(t *testing.T) {
 	assert.Equal(t, "token-secret-for-loki", actualToken) // `token-secret-for-loki` is the answered mock by Gock in `setupGockForServiceAccounts(...)`
 }
 
-func verifySandboxUserConfigFiles(t *testing.T, tempDir string, clusterAssertions ...userConfigClusterAssertions) {
+func verifyKsctlConfigFiles(t *testing.T, tempDir string, clusterAssertions ...userConfigClusterAssertions) {
 	tempDirInfo, err := os.ReadDir(tempDir)
 	require.NoError(t, err)
 	assert.Len(t, tempDirInfo, 2)
@@ -241,11 +241,11 @@ func verifySandboxUserConfigFiles(t *testing.T, tempDir string, clusterAssertion
 		content, err := os.ReadFile(path.Join(tempDir, userDir.Name(), userDirInfo[0].Name()))
 		require.NoError(t, err)
 
-		sandboxUserconfig := configuration.SandboxUserConfig{}
-		err = yaml.Unmarshal(content, &sandboxUserconfig)
+		ksctlConfig := configuration.KsctlConfig{}
+		err = yaml.Unmarshal(content, &ksctlConfig)
 		require.NoError(t, err)
 
-		userConfig := assertSandboxUserConfig(t, sandboxUserconfig, userDir.Name()).
+		userConfig := assertKsctlConfig(t, ksctlConfig, userDir.Name()).
 			hasNumberOfClusters(len(clusterAssertions))
 		for _, applyAssertion := range clusterAssertions {
 			applyAssertion(t, userDir.Name(), userConfig)
@@ -253,52 +253,52 @@ func verifySandboxUserConfigFiles(t *testing.T, tempDir string, clusterAssertion
 	}
 }
 
-type userConfigClusterAssertions func(*testing.T, string, *sandboxUserConfigAssertion)
+type userConfigClusterAssertions func(*testing.T, string, *ksctlConfigAssertion)
 
 func hasHost() userConfigClusterAssertions {
-	return func(t *testing.T, name string, assertion *sandboxUserConfigAssertion) {
+	return func(t *testing.T, name string, assertion *ksctlConfigAssertion) {
 		assertion.hasCluster("host", "host", configuration.Host)
 	}
 }
 
 func hasMember(memberName, subDomain string) userConfigClusterAssertions {
-	return func(t *testing.T, name string, assertion *sandboxUserConfigAssertion) {
+	return func(t *testing.T, name string, assertion *ksctlConfigAssertion) {
 		assertion.hasCluster(memberName, subDomain, configuration.Member)
 	}
 }
 
-// SandboxUserConfig assertions
+// KsctlConfig assertions
 
-type sandboxUserConfigAssertion struct {
-	t                 *testing.T
-	sandboxUserConfig configuration.SandboxUserConfig
-	saBaseName        string
+type ksctlConfigAssertion struct {
+	t           *testing.T
+	ksctlConfig configuration.KsctlConfig
+	saBaseName  string
 }
 
-func assertSandboxUserConfig(t *testing.T, sandboxUserConfig configuration.SandboxUserConfig, saBaseName string) *sandboxUserConfigAssertion {
-	require.NotNil(t, sandboxUserConfig)
-	assert.Equal(t, saBaseName, sandboxUserConfig.Name)
-	return &sandboxUserConfigAssertion{
-		t:                 t,
-		sandboxUserConfig: sandboxUserConfig,
-		saBaseName:        saBaseName,
+func assertKsctlConfig(t *testing.T, ksctlConfig configuration.KsctlConfig, saBaseName string) *ksctlConfigAssertion {
+	require.NotNil(t, ksctlConfig)
+	assert.Equal(t, saBaseName, ksctlConfig.Name)
+	return &ksctlConfigAssertion{
+		t:           t,
+		ksctlConfig: ksctlConfig,
+		saBaseName:  saBaseName,
 	}
 }
 
-func (a *sandboxUserConfigAssertion) hasNumberOfClusters(number int) *sandboxUserConfigAssertion {
-	require.Len(a.t, a.sandboxUserConfig.ClusterAccessDefinitions, number)
+func (a *ksctlConfigAssertion) hasNumberOfClusters(number int) *ksctlConfigAssertion {
+	require.Len(a.t, a.ksctlConfig.ClusterAccessDefinitions, number)
 	return a
 }
 
-func (a *sandboxUserConfigAssertion) hasCluster(clusterName, subDomain string, clusterType configuration.ClusterType) {
-	require.NotNil(a.t, a.sandboxUserConfig.ClusterAccessDefinitions[clusterName])
+func (a *ksctlConfigAssertion) hasCluster(clusterName, subDomain string, clusterType configuration.ClusterType) {
+	require.NotNil(a.t, a.ksctlConfig.ClusterAccessDefinitions[clusterName])
 
-	assert.NotNil(a.t, a.sandboxUserConfig.ClusterAccessDefinitions[clusterName])
-	assert.Equal(a.t, clusterType, a.sandboxUserConfig.ClusterAccessDefinitions[clusterName].ClusterType)
-	assert.Equal(a.t, fmt.Sprintf("sandbox.%s.openshiftapps.com", subDomain), a.sandboxUserConfig.ClusterAccessDefinitions[clusterName].ServerName)
-	assert.Equal(a.t, fmt.Sprintf("https://api.sandbox.%s.openshiftapps.com:6443", subDomain), a.sandboxUserConfig.ClusterAccessDefinitions[clusterName].ServerAPI)
+	assert.NotNil(a.t, a.ksctlConfig.ClusterAccessDefinitions[clusterName])
+	assert.Equal(a.t, clusterType, a.ksctlConfig.ClusterAccessDefinitions[clusterName].ClusterType)
+	assert.Equal(a.t, fmt.Sprintf("sandbox.%s.openshiftapps.com", subDomain), a.ksctlConfig.ClusterAccessDefinitions[clusterName].ServerName)
+	assert.Equal(a.t, fmt.Sprintf("https://api.sandbox.%s.openshiftapps.com:6443", subDomain), a.ksctlConfig.ClusterAccessDefinitions[clusterName].ServerAPI)
 
-	assert.Equal(a.t, fmt.Sprintf("token-secret-for-%s", a.saBaseName), a.sandboxUserConfig.ClusterAccessDefinitions[clusterName].Token)
+	assert.Equal(a.t, fmt.Sprintf("token-secret-for-%s", a.saBaseName), a.ksctlConfig.ClusterAccessDefinitions[clusterName].Token)
 }
 
 func setupGockForServiceAccounts(t *testing.T, apiEndpoint string, sas ...*corev1.ServiceAccount) {

--- a/pkg/cmd/adm/register_member.go
+++ b/pkg/cmd/adm/register_member.go
@@ -94,7 +94,7 @@ func registerMemberCluster(ctx *clicontext.CommandContext, newCommand client.Com
 
 func disableAutomaticApproval(hostClusterConfig configuration.ClusterConfig, cl runtimeclient.Client) error {
 	configs := &toolchainv1alpha1.ToolchainConfigList{}
-	if err := cl.List(context.TODO(), configs, runtimeclient.InNamespace(hostClusterConfig.SandboxNamespace)); err != nil {
+	if err := cl.List(context.TODO(), configs, runtimeclient.InNamespace(hostClusterConfig.KubeSawNamespace)); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/adm/register_member.go
+++ b/pkg/cmd/adm/register_member.go
@@ -94,7 +94,7 @@ func registerMemberCluster(ctx *clicontext.CommandContext, newCommand client.Com
 
 func disableAutomaticApproval(hostClusterConfig configuration.ClusterConfig, cl runtimeclient.Client) error {
 	configs := &toolchainv1alpha1.ToolchainConfigList{}
-	if err := cl.List(context.TODO(), configs, runtimeclient.InNamespace(hostClusterConfig.KubeSawNamespace)); err != nil {
+	if err := cl.List(context.TODO(), configs, runtimeclient.InNamespace(hostClusterConfig.OperatorNamespace)); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/adm/restart.go
+++ b/pkg/cmd/adm/restart.go
@@ -58,7 +58,7 @@ func restart(ctx *clicontext.CommandContext, clusterName string, deployments ...
 	deploymentName := deployments[0]
 
 	if !ctx.AskForConfirmation(
-		ioutils.WithMessagef("restart the deployment '%s' in namespace '%s'", deploymentName, cfg.SandboxNamespace)) {
+		ioutils.WithMessagef("restart the deployment '%s' in namespace '%s'", deploymentName, cfg.KubeSawNamespace)) {
 		return nil
 	}
 	return restartDeployment(ctx, cl, cfg, deploymentName)
@@ -66,7 +66,7 @@ func restart(ctx *clicontext.CommandContext, clusterName string, deployments ...
 
 func restartDeployment(ctx *clicontext.CommandContext, cl runtimeclient.Client, cfg configuration.ClusterConfig, deploymentName string) error {
 	namespacedName := types.NamespacedName{
-		Namespace: cfg.SandboxNamespace,
+		Namespace: cfg.KubeSawNamespace,
 		Name:      deploymentName,
 	}
 
@@ -92,13 +92,13 @@ func restartDeployment(ctx *clicontext.CommandContext, cl runtimeclient.Client, 
 func restartHostOperator(ctx *clicontext.CommandContext, hostClient runtimeclient.Client, hostConfig configuration.ClusterConfig) error {
 	deployments := &appsv1.DeploymentList{}
 	if err := hostClient.List(context.TODO(), deployments,
-		runtimeclient.InNamespace(hostConfig.SandboxNamespace),
+		runtimeclient.InNamespace(hostConfig.KubeSawNamespace),
 		runtimeclient.MatchingLabels{"olm.owner.namespace": "toolchain-host-operator"}); err != nil {
 		return err
 	}
 	if len(deployments.Items) != 1 {
 		return fmt.Errorf("there should be a single deployment matching the label olm.owner.namespace=toolchain-host-operator in %s ns, but %d was found. "+
-			"It's not possible to restart the Host Operator deployment", hostConfig.SandboxNamespace, len(deployments.Items))
+			"It's not possible to restart the Host Operator deployment", hostConfig.KubeSawNamespace, len(deployments.Items))
 	}
 
 	return restartDeployment(ctx, hostClient, hostConfig, deployments.Items[0].Name)
@@ -106,14 +106,14 @@ func restartHostOperator(ctx *clicontext.CommandContext, hostClient runtimeclien
 
 func printExistingDeployments(term ioutils.Terminal, cl runtimeclient.Client, cfg configuration.ClusterConfig) error {
 	deployments := &appsv1.DeploymentList{}
-	if err := cl.List(context.TODO(), deployments, runtimeclient.InNamespace(cfg.SandboxNamespace)); err != nil {
+	if err := cl.List(context.TODO(), deployments, runtimeclient.InNamespace(cfg.KubeSawNamespace)); err != nil {
 		return err
 	}
 	deploymentList := "\n"
 	for _, deployment := range deployments.Items {
 		deploymentList += fmt.Sprintf("%s\n", deployment.Name)
 	}
-	term.PrintContextSeparatorWithBodyf(deploymentList, "Existing deployments in %s namespace", cfg.SandboxNamespace)
+	term.PrintContextSeparatorWithBodyf(deploymentList, "Existing deployments in %s namespace", cfg.KubeSawNamespace)
 	return nil
 }
 

--- a/pkg/cmd/adm/restart.go
+++ b/pkg/cmd/adm/restart.go
@@ -58,7 +58,7 @@ func restart(ctx *clicontext.CommandContext, clusterName string, deployments ...
 	deploymentName := deployments[0]
 
 	if !ctx.AskForConfirmation(
-		ioutils.WithMessagef("restart the deployment '%s' in namespace '%s'", deploymentName, cfg.KubeSawNamespace)) {
+		ioutils.WithMessagef("restart the deployment '%s' in namespace '%s'", deploymentName, cfg.OperatorNamespace)) {
 		return nil
 	}
 	return restartDeployment(ctx, cl, cfg, deploymentName)
@@ -66,7 +66,7 @@ func restart(ctx *clicontext.CommandContext, clusterName string, deployments ...
 
 func restartDeployment(ctx *clicontext.CommandContext, cl runtimeclient.Client, cfg configuration.ClusterConfig, deploymentName string) error {
 	namespacedName := types.NamespacedName{
-		Namespace: cfg.KubeSawNamespace,
+		Namespace: cfg.OperatorNamespace,
 		Name:      deploymentName,
 	}
 
@@ -92,13 +92,13 @@ func restartDeployment(ctx *clicontext.CommandContext, cl runtimeclient.Client, 
 func restartHostOperator(ctx *clicontext.CommandContext, hostClient runtimeclient.Client, hostConfig configuration.ClusterConfig) error {
 	deployments := &appsv1.DeploymentList{}
 	if err := hostClient.List(context.TODO(), deployments,
-		runtimeclient.InNamespace(hostConfig.KubeSawNamespace),
+		runtimeclient.InNamespace(hostConfig.OperatorNamespace),
 		runtimeclient.MatchingLabels{"olm.owner.namespace": "toolchain-host-operator"}); err != nil {
 		return err
 	}
 	if len(deployments.Items) != 1 {
 		return fmt.Errorf("there should be a single deployment matching the label olm.owner.namespace=toolchain-host-operator in %s ns, but %d was found. "+
-			"It's not possible to restart the Host Operator deployment", hostConfig.KubeSawNamespace, len(deployments.Items))
+			"It's not possible to restart the Host Operator deployment", hostConfig.OperatorNamespace, len(deployments.Items))
 	}
 
 	return restartDeployment(ctx, hostClient, hostConfig, deployments.Items[0].Name)
@@ -106,14 +106,14 @@ func restartHostOperator(ctx *clicontext.CommandContext, hostClient runtimeclien
 
 func printExistingDeployments(term ioutils.Terminal, cl runtimeclient.Client, cfg configuration.ClusterConfig) error {
 	deployments := &appsv1.DeploymentList{}
-	if err := cl.List(context.TODO(), deployments, runtimeclient.InNamespace(cfg.KubeSawNamespace)); err != nil {
+	if err := cl.List(context.TODO(), deployments, runtimeclient.InNamespace(cfg.OperatorNamespace)); err != nil {
 		return err
 	}
 	deploymentList := "\n"
 	for _, deployment := range deployments.Items {
 		deploymentList += fmt.Sprintf("%s\n", deployment.Name)
 	}
-	term.PrintContextSeparatorWithBodyf(deploymentList, "Existing deployments in %s namespace", cfg.KubeSawNamespace)
+	term.PrintContextSeparatorWithBodyf(deploymentList, "Existing deployments in %s namespace", cfg.OperatorNamespace)
 	return nil
 }
 

--- a/pkg/cmd/adm/setup.go
+++ b/pkg/cmd/adm/setup.go
@@ -33,7 +33,7 @@ ksctl adm setup ./path/to/kubesaw-stage.openshiftapps.com/kubesaw-admins.yaml --
 			return Setup(term, resources.Resources, f)
 		},
 	}
-	command.Flags().StringVarP(&f.kubeSawAdminsFile, "kubesaw-admins", "c", "", "Use the given sandbox config file")
+	command.Flags().StringVarP(&f.kubeSawAdminsFile, "kubesaw-admins", "c", "", "Use the given kubesaw-admin file")
 	command.Flags().StringVarP(&f.outDir, "out-dir", "o", "", "Directory where generated manifests should be stored")
 	command.Flags().BoolVarP(&f.singleCluster, "single-cluster", "s", false, "If host and member are deployed to the same cluster")
 	command.Flags().StringVar(&f.hostRootDir, "host-root-dir", "host", "The root directory name for host manifests")

--- a/pkg/cmd/adm/setup_test.go
+++ b/pkg/cmd/adm/setup_test.go
@@ -257,7 +257,7 @@ func createKubeconfigFiles(t *testing.T, contents ...string) []string {
 	return fileNames
 }
 
-const sandboxKubeconfigContent = `
+const ksctlKubeconfigContent = `
 apiVersion: v1
 clusters:
 - cluster:
@@ -286,7 +286,7 @@ users:
     token: my-cool-token
 `
 
-const sandboxKubeconfigContentMember2 = `
+const ksctlKubeconfigContentMember2 = `
 apiVersion: v1
 clusters:
 - cluster:

--- a/pkg/cmd/adm/unregister_member.go
+++ b/pkg/cmd/adm/unregister_member.go
@@ -45,7 +45,7 @@ func UnregisterMemberCluster(ctx *clicontext.CommandContext, clusterName string)
 	clusterResourceName := fmt.Sprintf("%s-%s", clusterDef.ClusterType, clusterDef.ServerName)
 
 	toolchainCluster := &toolchainv1alpha1.ToolchainCluster{}
-	if err := hostClusterClient.Get(context.TODO(), types.NamespacedName{Namespace: hostClusterConfig.KubeSawNamespace, Name: clusterResourceName}, toolchainCluster); err != nil {
+	if err := hostClusterClient.Get(context.TODO(), types.NamespacedName{Namespace: hostClusterConfig.OperatorNamespace, Name: clusterResourceName}, toolchainCluster); err != nil {
 		return err
 	}
 	if err := ctx.PrintObject(toolchainCluster, "Toolchain Member cluster"); err != nil {

--- a/pkg/cmd/adm/unregister_member.go
+++ b/pkg/cmd/adm/unregister_member.go
@@ -45,7 +45,7 @@ func UnregisterMemberCluster(ctx *clicontext.CommandContext, clusterName string)
 	clusterResourceName := fmt.Sprintf("%s-%s", clusterDef.ClusterType, clusterDef.ServerName)
 
 	toolchainCluster := &toolchainv1alpha1.ToolchainCluster{}
-	if err := hostClusterClient.Get(context.TODO(), types.NamespacedName{Namespace: hostClusterConfig.SandboxNamespace, Name: clusterResourceName}, toolchainCluster); err != nil {
+	if err := hostClusterClient.Get(context.TODO(), types.NamespacedName{Namespace: hostClusterConfig.KubeSawNamespace, Name: clusterResourceName}, toolchainCluster); err != nil {
 		return err
 	}
 	if err := ctx.PrintObject(toolchainCluster, "Toolchain Member cluster"); err != nil {

--- a/pkg/cmd/adm/unregister_member_test.go
+++ b/pkg/cmd/adm/unregister_member_test.go
@@ -118,6 +118,6 @@ func TestUnregisterMemberLacksPermissions(t *testing.T) {
 	err := UnregisterMemberCluster(ctx, "member1")
 
 	// then
-	require.EqualError(t, err, "sandbox command failed: the token in your ksctl.yaml file is missing")
+	require.EqualError(t, err, "ksctl command failed: the token in your ksctl.yaml file is missing")
 	AssertToolchainClusterSpec(t, fakeClient, toolchainCluster)
 }

--- a/pkg/cmd/approve.go
+++ b/pkg/cmd/approve.go
@@ -61,7 +61,7 @@ func ByName(name string) LookupUserSignup {
 	return func(cfg configuration.ClusterConfig, cl runtimeclient.Client) (*toolchainv1alpha1.UserSignup, error) {
 		userSignup := &toolchainv1alpha1.UserSignup{}
 		err := cl.Get(context.TODO(), types.NamespacedName{
-			Namespace: cfg.KubeSawNamespace,
+			Namespace: cfg.OperatorNamespace,
 			Name:      name,
 		}, userSignup)
 		return userSignup, err
@@ -71,7 +71,7 @@ func ByName(name string) LookupUserSignup {
 func ByEmailAddress(emailAddress string) LookupUserSignup {
 	return func(cfg configuration.ClusterConfig, cl runtimeclient.Client) (*toolchainv1alpha1.UserSignup, error) {
 		usersignups := toolchainv1alpha1.UserSignupList{}
-		if err := cl.List(context.TODO(), &usersignups, runtimeclient.InNamespace(cfg.KubeSawNamespace), runtimeclient.MatchingLabels{
+		if err := cl.List(context.TODO(), &usersignups, runtimeclient.InNamespace(cfg.OperatorNamespace), runtimeclient.MatchingLabels{
 			toolchainv1alpha1.UserSignupUserEmailHashLabelKey: hash.EncodeString(emailAddress),
 		}); err != nil {
 			return nil, err

--- a/pkg/cmd/approve.go
+++ b/pkg/cmd/approve.go
@@ -61,7 +61,7 @@ func ByName(name string) LookupUserSignup {
 	return func(cfg configuration.ClusterConfig, cl runtimeclient.Client) (*toolchainv1alpha1.UserSignup, error) {
 		userSignup := &toolchainv1alpha1.UserSignup{}
 		err := cl.Get(context.TODO(), types.NamespacedName{
-			Namespace: cfg.SandboxNamespace,
+			Namespace: cfg.KubeSawNamespace,
 			Name:      name,
 		}, userSignup)
 		return userSignup, err
@@ -71,7 +71,7 @@ func ByName(name string) LookupUserSignup {
 func ByEmailAddress(emailAddress string) LookupUserSignup {
 	return func(cfg configuration.ClusterConfig, cl runtimeclient.Client) (*toolchainv1alpha1.UserSignup, error) {
 		usersignups := toolchainv1alpha1.UserSignupList{}
-		if err := cl.List(context.TODO(), &usersignups, runtimeclient.InNamespace(cfg.SandboxNamespace), runtimeclient.MatchingLabels{
+		if err := cl.List(context.TODO(), &usersignups, runtimeclient.InNamespace(cfg.KubeSawNamespace), runtimeclient.MatchingLabels{
 			toolchainv1alpha1.UserSignupUserEmailHashLabelKey: hash.EncodeString(emailAddress),
 		}); err != nil {
 			return nil, err

--- a/pkg/cmd/ban.go
+++ b/pkg/cmd/ban.go
@@ -58,7 +58,7 @@ func CreateBannedUser(ctx *clicontext.CommandContext, userSignupName string, con
 		return err
 	}
 
-	userSignup, err := client.GetUserSignup(cl, cfg.KubeSawNamespace, userSignupName)
+	userSignup, err := client.GetUserSignup(cl, cfg.OperatorNamespace, userSignupName)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func CreateBannedUser(ctx *clicontext.CommandContext, userSignupName string, con
 	}
 
 	bannedUsers := &toolchainv1alpha1.BannedUserList{}
-	if err := cl.List(context.TODO(), bannedUsers, runtimeclient.MatchingLabels(bannedUser.Labels), runtimeclient.InNamespace(cfg.KubeSawNamespace)); err != nil {
+	if err := cl.List(context.TODO(), bannedUsers, runtimeclient.MatchingLabels(bannedUser.Labels), runtimeclient.InNamespace(cfg.OperatorNamespace)); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/ban.go
+++ b/pkg/cmd/ban.go
@@ -58,7 +58,7 @@ func CreateBannedUser(ctx *clicontext.CommandContext, userSignupName string, con
 		return err
 	}
 
-	userSignup, err := client.GetUserSignup(cl, cfg.SandboxNamespace, userSignupName)
+	userSignup, err := client.GetUserSignup(cl, cfg.KubeSawNamespace, userSignupName)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func CreateBannedUser(ctx *clicontext.CommandContext, userSignupName string, con
 	}
 
 	bannedUsers := &toolchainv1alpha1.BannedUserList{}
-	if err := cl.List(context.TODO(), bannedUsers, runtimeclient.MatchingLabels(bannedUser.Labels), runtimeclient.InNamespace(cfg.SandboxNamespace)); err != nil {
+	if err := cl.List(context.TODO(), bannedUsers, runtimeclient.MatchingLabels(bannedUser.Labels), runtimeclient.InNamespace(cfg.KubeSawNamespace)); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/ban_test.go
+++ b/pkg/cmd/ban_test.go
@@ -224,6 +224,6 @@ func TestCreateBannedUserLacksPermissions(t *testing.T) {
 	})
 
 	// then
-	require.EqualError(t, err, "sandbox command failed: the token in your ksctl.yaml file is missing")
+	require.EqualError(t, err, "ksctl command failed: the token in your ksctl.yaml file is missing")
 	AssertUserSignupSpec(t, fakeClient, userSignup)
 }

--- a/pkg/cmd/base_kubectl.go
+++ b/pkg/cmd/base_kubectl.go
@@ -55,12 +55,12 @@ func setupKubectlCmd(newCmd newCmd) *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if !cmd.Flag("namespace").Changed { // default to sandbox namespace
-			kubeConfigFlags.Namespace = &cfg.SandboxNamespace
+		if !cmd.Flag("namespace").Changed { // default to kubeSaw namespace
+			kubeConfigFlags.Namespace = &cfg.KubeSawNamespace
 		}
 		kubeConfigFlags.APIServer = &cfg.ServerAPI
 		kubeConfigFlags.BearerToken = &cfg.Token
-		kubeconfig, err := client.EnsureSandboxCliConfigFile()
+		kubeconfig, err := client.EnsureKsctlConfigFile()
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/base_kubectl.go
+++ b/pkg/cmd/base_kubectl.go
@@ -56,7 +56,7 @@ func setupKubectlCmd(newCmd newCmd) *cobra.Command {
 			return err
 		}
 		if !cmd.Flag("namespace").Changed { // default to kubeSaw namespace
-			kubeConfigFlags.Namespace = &cfg.KubeSawNamespace
+			kubeConfigFlags.Namespace = &cfg.OperatorNamespace
 		}
 		kubeConfigFlags.APIServer = &cfg.ServerAPI
 		kubeConfigFlags.BearerToken = &cfg.Token

--- a/pkg/cmd/create_social_event.go
+++ b/pkg/cmd/create_social_event.go
@@ -79,7 +79,7 @@ func CreateSocialEvent(ctx *clicontext.CommandContext, startDate, endDate, descr
 	}
 	// check that the user and space tiers exist
 	if err := cl.Get(context.TODO(), types.NamespacedName{
-		Namespace: cfg.SandboxNamespace,
+		Namespace: cfg.KubeSawNamespace,
 		Name:      userTier,
 	}, &toolchainv1alpha1.UserTier{}); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -87,7 +87,7 @@ func CreateSocialEvent(ctx *clicontext.CommandContext, startDate, endDate, descr
 		}
 	}
 	if err := cl.Get(context.TODO(), types.NamespacedName{
-		Namespace: cfg.SandboxNamespace,
+		Namespace: cfg.KubeSawNamespace,
 		Name:      spaceTier,
 	}, &toolchainv1alpha1.NSTemplateTier{}); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -97,7 +97,7 @@ func CreateSocialEvent(ctx *clicontext.CommandContext, startDate, endDate, descr
 
 	se := &toolchainv1alpha1.SocialEvent{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: cfg.SandboxNamespace,
+			Namespace: cfg.KubeSawNamespace,
 			Name:      code,
 		},
 		Spec: toolchainv1alpha1.SocialEventSpec{

--- a/pkg/cmd/create_social_event.go
+++ b/pkg/cmd/create_social_event.go
@@ -79,7 +79,7 @@ func CreateSocialEvent(ctx *clicontext.CommandContext, startDate, endDate, descr
 	}
 	// check that the user and space tiers exist
 	if err := cl.Get(context.TODO(), types.NamespacedName{
-		Namespace: cfg.KubeSawNamespace,
+		Namespace: cfg.OperatorNamespace,
 		Name:      userTier,
 	}, &toolchainv1alpha1.UserTier{}); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -87,7 +87,7 @@ func CreateSocialEvent(ctx *clicontext.CommandContext, startDate, endDate, descr
 		}
 	}
 	if err := cl.Get(context.TODO(), types.NamespacedName{
-		Namespace: cfg.KubeSawNamespace,
+		Namespace: cfg.OperatorNamespace,
 		Name:      spaceTier,
 	}, &toolchainv1alpha1.NSTemplateTier{}); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -97,7 +97,7 @@ func CreateSocialEvent(ctx *clicontext.CommandContext, startDate, endDate, descr
 
 	se := &toolchainv1alpha1.SocialEvent{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: cfg.KubeSawNamespace,
+			Namespace: cfg.OperatorNamespace,
 			Name:      code,
 		},
 		Spec: toolchainv1alpha1.SocialEventSpec{

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -37,7 +37,7 @@ func Delete(ctx *clicontext.CommandContext, args ...string) error {
 	if err != nil {
 		return err
 	}
-	userSignup, err := client.GetUserSignup(cl, cfg.KubeSawNamespace, args[0])
+	userSignup, err := client.GetUserSignup(cl, cfg.OperatorNamespace, args[0])
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -37,7 +37,7 @@ func Delete(ctx *clicontext.CommandContext, args ...string) error {
 	if err != nil {
 		return err
 	}
-	userSignup, err := client.GetUserSignup(cl, cfg.SandboxNamespace, args[0])
+	userSignup, err := client.GetUserSignup(cl, cfg.KubeSawNamespace, args[0])
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/delete_test.go
+++ b/pkg/cmd/delete_test.go
@@ -89,7 +89,7 @@ func TestDeleteLacksPermissions(t *testing.T) {
 	err := cmd.Delete(ctx, userSignup.Name)
 
 	// then
-	require.EqualError(t, err, "sandbox command failed: the token in your ksctl.yaml file is missing")
+	require.EqualError(t, err, "ksctl command failed: the token in your ksctl.yaml file is missing")
 	AssertUserSignupSpec(t, fakeClient, userSignup)
 }
 

--- a/pkg/cmd/remove_space_users.go
+++ b/pkg/cmd/remove_space_users.go
@@ -50,7 +50,7 @@ func RemoveSpaceUsers(ctx *clicontext.CommandContext, spaceName string, usersToR
 
 	// get Space
 	ctx.Println("Checking space...")
-	space, err := client.GetSpace(cl, cfg.SandboxNamespace, spaceName)
+	space, err := client.GetSpace(cl, cfg.KubeSawNamespace, spaceName)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func RemoveSpaceUsers(ctx *clicontext.CommandContext, spaceName string, usersToR
 	// get SpaceBindings to delete
 	spaceBindingsToDelete := []*toolchainv1alpha1.SpaceBinding{}
 	for _, murName := range usersToRemove {
-		sbs, err := client.ListSpaceBindings(cl, cfg.SandboxNamespace, client.ForSpace(spaceName), client.ForMasterUserRecord(murName))
+		sbs, err := client.ListSpaceBindings(cl, cfg.KubeSawNamespace, client.ForSpace(spaceName), client.ForMasterUserRecord(murName))
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/remove_space_users.go
+++ b/pkg/cmd/remove_space_users.go
@@ -50,7 +50,7 @@ func RemoveSpaceUsers(ctx *clicontext.CommandContext, spaceName string, usersToR
 
 	// get Space
 	ctx.Println("Checking space...")
-	space, err := client.GetSpace(cl, cfg.KubeSawNamespace, spaceName)
+	space, err := client.GetSpace(cl, cfg.OperatorNamespace, spaceName)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func RemoveSpaceUsers(ctx *clicontext.CommandContext, spaceName string, usersToR
 	// get SpaceBindings to delete
 	spaceBindingsToDelete := []*toolchainv1alpha1.SpaceBinding{}
 	for _, murName := range usersToRemove {
-		sbs, err := client.ListSpaceBindings(cl, cfg.KubeSawNamespace, client.ForSpace(spaceName), client.ForMasterUserRecord(murName))
+		sbs, err := client.ListSpaceBindings(cl, cfg.OperatorNamespace, client.ForSpace(spaceName), client.ForMasterUserRecord(murName))
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/retarget.go
+++ b/pkg/cmd/retarget.go
@@ -43,7 +43,7 @@ func Retarget(ctx *clicontext.CommandContext, spaceName, targetCluster string) e
 		return err
 	}
 
-	space, err := client.GetSpace(hostClusterClient, hostClusterConfig.SandboxNamespace, spaceName)
+	space, err := client.GetSpace(hostClusterClient, hostClusterConfig.KubeSawNamespace, spaceName)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func Retarget(ctx *clicontext.CommandContext, spaceName, targetCluster string) e
 	if creator == "" {
 		return fmt.Errorf("spaces without the creator label are not supported")
 	}
-	userSignup, err := client.GetUserSignup(hostClusterClient, hostClusterConfig.SandboxNamespace, creator)
+	userSignup, err := client.GetUserSignup(hostClusterClient, hostClusterConfig.KubeSawNamespace, creator)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/retarget.go
+++ b/pkg/cmd/retarget.go
@@ -43,7 +43,7 @@ func Retarget(ctx *clicontext.CommandContext, spaceName, targetCluster string) e
 		return err
 	}
 
-	space, err := client.GetSpace(hostClusterClient, hostClusterConfig.KubeSawNamespace, spaceName)
+	space, err := client.GetSpace(hostClusterClient, hostClusterConfig.OperatorNamespace, spaceName)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func Retarget(ctx *clicontext.CommandContext, spaceName, targetCluster string) e
 	if creator == "" {
 		return fmt.Errorf("spaces without the creator label are not supported")
 	}
-	userSignup, err := client.GetUserSignup(hostClusterClient, hostClusterConfig.KubeSawNamespace, creator)
+	userSignup, err := client.GetUserSignup(hostClusterClient, hostClusterConfig.OperatorNamespace, creator)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -39,7 +39,7 @@ func Status(ctx *clicontext.CommandContext) error {
 		return err
 	}
 	namespacedName := types.NamespacedName{
-		Namespace: cfg.KubeSawNamespace,
+		Namespace: cfg.OperatorNamespace,
 		Name:      "toolchain-status",
 	}
 	status := &toolchainv1alpha1.ToolchainStatus{}

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -39,7 +39,7 @@ func Status(ctx *clicontext.CommandContext) error {
 		return err
 	}
 	namespacedName := types.NamespacedName{
-		Namespace: cfg.SandboxNamespace,
+		Namespace: cfg.KubeSawNamespace,
 		Name:      "toolchain-status",
 	}
 	status := &toolchainv1alpha1.ToolchainStatus{}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -19,40 +19,40 @@ var (
 	Verbose        bool
 )
 
-type SandboxUserConfig struct {
+type KsctlConfig struct {
 	ClusterAccessDefinitions `yaml:",inline"`
 	Name                     string `yaml:"name"`
 }
 
 // Load reads in config file and ENV variables if set.
-func Load(term ioutils.Terminal) (SandboxUserConfig, string, error) {
+func Load(term ioutils.Terminal) (KsctlConfig, string, error) {
 	path := ConfigFileFlag
 	if path == "" {
 		// Find home directory.
 		home, err := homedir.Dir()
 		if err != nil {
-			return SandboxUserConfig{}, "", errs.Wrap(err, "unable to read home directory")
+			return KsctlConfig{}, "", errs.Wrap(err, "unable to read home directory")
 		}
 		path = filepath.Join(home, ".ksctl.yaml")
 
 		if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
 			if _, err := os.Stat(filepath.Join(home, ".sandbox.yaml")); err != nil && !os.IsNotExist(err) {
-				return SandboxUserConfig{}, "", err
+				return KsctlConfig{}, "", err
 			} else if err == nil {
 				path = filepath.Join(home, ".sandbox.yaml")
 				term.Println("The default location of ~/.sandbox.yaml file is deprecated. Rename it to ~/.ksctl.yaml")
 			}
 		} else if err != nil {
-			return SandboxUserConfig{}, "", err
+			return KsctlConfig{}, "", err
 		}
 	}
 
 	info, err := os.Stat(path)
 	if err != nil {
-		return SandboxUserConfig{}, "", errs.Wrapf(err, "unable to read the file '%s'", path)
+		return KsctlConfig{}, "", errs.Wrapf(err, "unable to read the file '%s'", path)
 	}
 	if info.IsDir() {
-		return SandboxUserConfig{}, "", fmt.Errorf("the '%s' is not file but a directory", path)
+		return KsctlConfig{}, "", fmt.Errorf("the '%s' is not file but a directory", path)
 	}
 
 	if Verbose {
@@ -61,13 +61,13 @@ func Load(term ioutils.Terminal) (SandboxUserConfig, string, error) {
 
 	bytes, err := os.ReadFile(path)
 	if err != nil {
-		return SandboxUserConfig{}, "", err
+		return KsctlConfig{}, "", err
 	}
-	sandboxUserConfig := SandboxUserConfig{}
-	if err := yaml.Unmarshal(bytes, &sandboxUserConfig); err != nil {
-		return SandboxUserConfig{}, "", err
+	ksctlConfig := KsctlConfig{}
+	if err := yaml.Unmarshal(bytes, &ksctlConfig); err != nil {
+		return KsctlConfig{}, "", err
 	}
-	return sandboxUserConfig, path, nil
+	return ksctlConfig, path, nil
 }
 
 const HostName = "host"
@@ -110,37 +110,37 @@ type ClusterNamespaces map[string]string
 
 // LoadClusterAccessDefinition loads ClusterAccessDefinition object from the config file and checks that all required parameters are set
 func LoadClusterAccessDefinition(term ioutils.Terminal, clusterName string) (ClusterAccessDefinition, error) {
-	sandboxUserConfig, _, err := Load(term)
+	ksctlConfig, _, err := Load(term)
 	if err != nil {
 		return ClusterAccessDefinition{}, err
 	}
-	return loadClusterAccessDefinition(sandboxUserConfig, clusterName)
+	return loadClusterAccessDefinition(ksctlConfig, clusterName)
 }
 
-func loadClusterAccessDefinition(sandboxUserConfig SandboxUserConfig, clusterName string) (ClusterAccessDefinition, error) {
+func loadClusterAccessDefinition(ksctlConfig KsctlConfig, clusterName string) (ClusterAccessDefinition, error) {
 	// try converted to camel case if kebab case is provided
-	clusterDef, ok := sandboxUserConfig.ClusterAccessDefinitions[utils.KebabToCamelCase(clusterName)]
+	clusterDef, ok := ksctlConfig.ClusterAccessDefinitions[utils.KebabToCamelCase(clusterName)]
 	if !ok {
 		// if not found, then also try original format (to cover situation when camel case is used)
-		if clusterDef, ok = sandboxUserConfig.ClusterAccessDefinitions[clusterName]; !ok {
+		if clusterDef, ok = ksctlConfig.ClusterAccessDefinitions[clusterName]; !ok {
 			return ClusterAccessDefinition{}, fmt.Errorf("the provided cluster-name '%s' is not present in your ksctl.yaml file. The available cluster names are\n"+
 				"------------------------\n%s\n"+
-				"------------------------", clusterName, strings.Join(getAllClusterNames(sandboxUserConfig), "\n"))
+				"------------------------", clusterName, strings.Join(getAllClusterNames(ksctlConfig), "\n"))
 		}
 	}
 	if clusterDef.ClusterType == "" {
-		return ClusterAccessDefinition{}, fmt.Errorf("sandbox command failed: 'cluster type' is not set for cluster '%s'", clusterName)
+		return ClusterAccessDefinition{}, fmt.Errorf("ksctl command failed: 'cluster type' is not set for cluster '%s'", clusterName)
 	}
 	if clusterDef.ServerAPI == "" {
-		return ClusterAccessDefinition{}, fmt.Errorf("sandbox command failed: The server API is not set for the cluster %s", clusterName)
+		return ClusterAccessDefinition{}, fmt.Errorf("ksctl command failed: The server API is not set for the cluster %s", clusterName)
 	}
 	if clusterDef.ServerName == "" {
-		return ClusterAccessDefinition{}, fmt.Errorf("sandbox command failed: The server name is not set for the cluster %s", clusterName)
+		return ClusterAccessDefinition{}, fmt.Errorf("ksctl command failed: The server name is not set for the cluster %s", clusterName)
 	}
 	return clusterDef, nil
 }
 
-func getAllClusterNames(config SandboxUserConfig) []string {
+func getAllClusterNames(config KsctlConfig) []string {
 	var clusterNames []string
 	for clusterName := range config.ClusterAccessDefinitions {
 		clusterNames = append(clusterNames, utils.CamelCaseToKebabCase(clusterName))
@@ -148,54 +148,54 @@ func getAllClusterNames(config SandboxUserConfig) []string {
 	return clusterNames
 }
 
-// ClusterConfig contains all parameters of a cluster loaded from SandboxUserConfig
-// plus all cluster names defined in the SandboxUserConfig
+// ClusterConfig contains all parameters of a cluster loaded from KsctlConfig
+// plus all cluster names defined in the KsctlConfig
 type ClusterConfig struct {
 	ClusterAccessDefinition
 	AllClusterNames  []string
 	ClusterName      string
 	Token            string
-	SandboxNamespace string
+	KubeSawNamespace string
 	PathToConfigFile string
 }
 
 // LoadClusterConfig loads ClusterConfig object from the config file and checks that all required parameters are set
 // as well as the token for the given name
 func LoadClusterConfig(term ioutils.Terminal, clusterName string) (ClusterConfig, error) {
-	sandboxUserConfig, path, err := Load(term)
+	ksctlConfig, path, err := Load(term)
 	if err != nil {
 		return ClusterConfig{}, err
 	}
-	clusterDef, err := loadClusterAccessDefinition(sandboxUserConfig, clusterName)
+	clusterDef, err := loadClusterAccessDefinition(ksctlConfig, clusterName)
 	if err != nil {
 		return ClusterConfig{}, err
 	}
 	if clusterDef.Token == "" {
-		return ClusterConfig{}, fmt.Errorf("sandbox command failed: the token in your ksctl.yaml file is missing")
+		return ClusterConfig{}, fmt.Errorf("ksctl command failed: the token in your ksctl.yaml file is missing")
 	}
-	var sandboxNamespace string
+	var kubeSawNamespace string
 	if clusterName == HostName {
-		sandboxNamespace = os.Getenv("HOST_OPERATOR_NAMESPACE")
-		if sandboxNamespace == "" {
-			sandboxNamespace = "toolchain-host-operator"
+		kubeSawNamespace = os.Getenv("HOST_OPERATOR_NAMESPACE")
+		if kubeSawNamespace == "" {
+			kubeSawNamespace = "toolchain-host-operator"
 		}
 	} else {
-		sandboxNamespace = os.Getenv("MEMBER_OPERATOR_NAMESPACE")
-		if sandboxNamespace == "" {
-			sandboxNamespace = "toolchain-member-operator"
+		kubeSawNamespace = os.Getenv("MEMBER_OPERATOR_NAMESPACE")
+		if kubeSawNamespace == "" {
+			kubeSawNamespace = "toolchain-member-operator"
 		}
 	}
 
 	if Verbose {
 		term.Printlnf("Using '%s' configuration for '%s' cluster running at '%s' and in namespace '%s'\n",
-			clusterName, clusterDef.ServerName, clusterDef.ServerAPI, sandboxNamespace)
+			clusterName, clusterDef.ServerName, clusterDef.ServerAPI, kubeSawNamespace)
 	}
 	return ClusterConfig{
 		ClusterAccessDefinition: clusterDef,
-		AllClusterNames:         getAllClusterNames(sandboxUserConfig),
+		AllClusterNames:         getAllClusterNames(ksctlConfig),
 		ClusterName:             clusterName,
 		Token:                   clusterDef.Token,
-		SandboxNamespace:        sandboxNamespace,
+		KubeSawNamespace:        kubeSawNamespace,
 		PathToConfigFile:        path,
 	}, nil
 }
@@ -207,7 +207,7 @@ func (c ClusterConfig) GetServerParam() string {
 
 // GetNamespaceParam returns the `--namespace=` param along with its actual value
 func (c ClusterConfig) GetNamespaceParam() string {
-	return "--namespace=" + c.SandboxNamespace
+	return "--namespace=" + c.KubeSawNamespace
 }
 
 // ConfigurePath returns the path to the 'configure' directory, using the clusterConfigName arg if it's not empty,

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -155,7 +155,7 @@ type ClusterConfig struct {
 	AllClusterNames   []string
 	ClusterName       string
 	Token             string
-	OperatorNamespace string
+	OperatorNamespace string // namespace where either the host-operator or the member-operator is deployed (depends on the cluster context)
 	PathToConfigFile  string
 }
 

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -152,11 +152,11 @@ func getAllClusterNames(config KsctlConfig) []string {
 // plus all cluster names defined in the KsctlConfig
 type ClusterConfig struct {
 	ClusterAccessDefinition
-	AllClusterNames  []string
-	ClusterName      string
-	Token            string
-	KubeSawNamespace string
-	PathToConfigFile string
+	AllClusterNames   []string
+	ClusterName       string
+	Token             string
+	OperatorNamespace string
+	PathToConfigFile  string
 }
 
 // LoadClusterConfig loads ClusterConfig object from the config file and checks that all required parameters are set
@@ -173,29 +173,29 @@ func LoadClusterConfig(term ioutils.Terminal, clusterName string) (ClusterConfig
 	if clusterDef.Token == "" {
 		return ClusterConfig{}, fmt.Errorf("ksctl command failed: the token in your ksctl.yaml file is missing")
 	}
-	var kubeSawNamespace string
+	var operatorNamespace string
 	if clusterName == HostName {
-		kubeSawNamespace = os.Getenv("HOST_OPERATOR_NAMESPACE")
-		if kubeSawNamespace == "" {
-			kubeSawNamespace = "toolchain-host-operator"
+		operatorNamespace = os.Getenv("HOST_OPERATOR_NAMESPACE")
+		if operatorNamespace == "" {
+			operatorNamespace = "toolchain-host-operator"
 		}
 	} else {
-		kubeSawNamespace = os.Getenv("MEMBER_OPERATOR_NAMESPACE")
-		if kubeSawNamespace == "" {
-			kubeSawNamespace = "toolchain-member-operator"
+		operatorNamespace = os.Getenv("MEMBER_OPERATOR_NAMESPACE")
+		if operatorNamespace == "" {
+			operatorNamespace = "toolchain-member-operator"
 		}
 	}
 
 	if Verbose {
 		term.Printlnf("Using '%s' configuration for '%s' cluster running at '%s' and in namespace '%s'\n",
-			clusterName, clusterDef.ServerName, clusterDef.ServerAPI, kubeSawNamespace)
+			clusterName, clusterDef.ServerName, clusterDef.ServerAPI, operatorNamespace)
 	}
 	return ClusterConfig{
 		ClusterAccessDefinition: clusterDef,
 		AllClusterNames:         getAllClusterNames(ksctlConfig),
 		ClusterName:             clusterName,
 		Token:                   clusterDef.Token,
-		KubeSawNamespace:        kubeSawNamespace,
+		OperatorNamespace:       operatorNamespace,
 		PathToConfigFile:        path,
 	}, nil
 }
@@ -207,7 +207,7 @@ func (c ClusterConfig) GetServerParam() string {
 
 // GetNamespaceParam returns the `--namespace=` param along with its actual value
 func (c ClusterConfig) GetNamespaceParam() string {
-	return "--namespace=" + c.KubeSawNamespace
+	return "--namespace=" + c.OperatorNamespace
 }
 
 // ConfigurePath returns the path to the 'configure' directory, using the clusterConfigName arg if it's not empty,

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -50,7 +50,7 @@ func TestLoadClusterConfig(t *testing.T) {
 
 						// then
 						require.NoError(t, err)
-						assert.Equal(t, namespaceName, cfg.KubeSawNamespace)
+						assert.Equal(t, namespaceName, cfg.OperatorNamespace)
 						assert.Equal(t, "--namespace="+namespaceName, cfg.GetNamespaceParam())
 						assert.Equal(t, clusterConfigParam.ClusterType, cfg.ClusterType)
 						assert.Equal(t, "cool-token", cfg.Token)
@@ -62,7 +62,7 @@ func TestLoadClusterConfig(t *testing.T) {
 						assert.True(t, strings.HasPrefix(cfg.PathToConfigFile, os.TempDir()))
 						assert.Contains(t, term.Output(), fmt.Sprintf("Using config file: '%s'", configuration.ConfigFileFlag))
 						assert.Contains(t, term.Output(), fmt.Sprintf("Using '%s' configuration for '%s' cluster running at '%s' and in namespace '%s'",
-							cfg.ClusterName, cfg.ServerName, cfg.ServerAPI, cfg.KubeSawNamespace))
+							cfg.ClusterName, cfg.ServerName, cfg.ServerAPI, cfg.OperatorNamespace))
 					})
 
 					t.Run("without verbose logs", func(t *testing.T) {
@@ -79,7 +79,7 @@ func TestLoadClusterConfig(t *testing.T) {
 						// don't repeat assertions above, just check that logs do NOT contain the following messages
 						assert.NotContains(t, term.Output(), fmt.Sprintf("Using config file: '%s'", configuration.ConfigFileFlag))
 						assert.NotContains(t, term.Output(), fmt.Sprintf("Using '%s' configuration for '%s' cluster running at '%s' and in namespace '%s'",
-							cfg.ClusterType, cfg.ServerName, cfg.ServerAPI, cfg.KubeSawNamespace))
+							cfg.ClusterType, cfg.ServerName, cfg.ServerAPI, cfg.OperatorNamespace))
 					})
 				})
 			}
@@ -100,7 +100,7 @@ func TestLoadClusterConfig(t *testing.T) {
 
 					// then
 					require.NoError(t, err, "ksctl command failed: The kubeSaw namespace is not set for the cluster "+clusterConfigParam.ClusterName)
-					assert.Equal(t, "custom-namespace", cfg.KubeSawNamespace)
+					assert.Equal(t, "custom-namespace", cfg.OperatorNamespace)
 				})
 			}
 
@@ -226,7 +226,7 @@ func TestLoadingClusterConfigWithNonexistentClusterName(t *testing.T) {
 	assert.Contains(t, err.Error(), "the provided cluster-name 'dummy' is not present in your ksctl.yaml file. The available cluster names are")
 	assert.Contains(t, err.Error(), "host")
 	assert.Contains(t, err.Error(), "member-1")
-	assert.Empty(t, cfg.KubeSawNamespace)
+	assert.Empty(t, cfg.OperatorNamespace)
 }
 
 func TestLoad(t *testing.T) {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -50,7 +50,7 @@ func TestLoadClusterConfig(t *testing.T) {
 
 						// then
 						require.NoError(t, err)
-						assert.Equal(t, namespaceName, cfg.SandboxNamespace)
+						assert.Equal(t, namespaceName, cfg.KubeSawNamespace)
 						assert.Equal(t, "--namespace="+namespaceName, cfg.GetNamespaceParam())
 						assert.Equal(t, clusterConfigParam.ClusterType, cfg.ClusterType)
 						assert.Equal(t, "cool-token", cfg.Token)
@@ -62,7 +62,7 @@ func TestLoadClusterConfig(t *testing.T) {
 						assert.True(t, strings.HasPrefix(cfg.PathToConfigFile, os.TempDir()))
 						assert.Contains(t, term.Output(), fmt.Sprintf("Using config file: '%s'", configuration.ConfigFileFlag))
 						assert.Contains(t, term.Output(), fmt.Sprintf("Using '%s' configuration for '%s' cluster running at '%s' and in namespace '%s'",
-							cfg.ClusterName, cfg.ServerName, cfg.ServerAPI, cfg.SandboxNamespace))
+							cfg.ClusterName, cfg.ServerName, cfg.ServerAPI, cfg.KubeSawNamespace))
 					})
 
 					t.Run("without verbose logs", func(t *testing.T) {
@@ -79,7 +79,7 @@ func TestLoadClusterConfig(t *testing.T) {
 						// don't repeat assertions above, just check that logs do NOT contain the following messages
 						assert.NotContains(t, term.Output(), fmt.Sprintf("Using config file: '%s'", configuration.ConfigFileFlag))
 						assert.NotContains(t, term.Output(), fmt.Sprintf("Using '%s' configuration for '%s' cluster running at '%s' and in namespace '%s'",
-							cfg.ClusterType, cfg.ServerName, cfg.ServerAPI, cfg.SandboxNamespace))
+							cfg.ClusterType, cfg.ServerName, cfg.ServerAPI, cfg.KubeSawNamespace))
 					})
 				})
 			}
@@ -88,7 +88,7 @@ func TestLoadClusterConfig(t *testing.T) {
 				clusterConfigParam.ClusterName = testCase.transform(clusterConfigParam.ClusterName)
 				clusterName := clusterConfigParam.ClusterName
 
-				t.Run("when sandbox namespace is set via global variable for "+clusterConfigParam.ClusterName, func(t *testing.T) {
+				t.Run("when kubeSaw namespace is set via global variable for "+clusterConfigParam.ClusterName, func(t *testing.T) {
 					// given
 					restore := test.SetEnvVarAndRestore(t, strings.ToUpper(clusterConfigParam.ClusterType.String())+"_OPERATOR_NAMESPACE", "custom-namespace")
 					t.Cleanup(restore)
@@ -99,8 +99,8 @@ func TestLoadClusterConfig(t *testing.T) {
 					cfg, err := configuration.LoadClusterConfig(term, clusterName)
 
 					// then
-					require.NoError(t, err, "sandbox command failed: The sandbox namespace is not set for the cluster "+clusterConfigParam.ClusterName)
-					assert.Equal(t, "custom-namespace", cfg.SandboxNamespace)
+					require.NoError(t, err, "ksctl command failed: The kubeSaw namespace is not set for the cluster "+clusterConfigParam.ClusterName)
+					assert.Equal(t, "custom-namespace", cfg.KubeSawNamespace)
 				})
 			}
 
@@ -117,7 +117,7 @@ func TestLoadClusterConfig(t *testing.T) {
 					cfg, err := configuration.LoadClusterConfig(term, clusterName)
 
 					// then
-					require.EqualError(t, err, "sandbox command failed: 'cluster type' is not set for cluster '"+clusterConfigParam.ClusterName+"'")
+					require.EqualError(t, err, "ksctl command failed: 'cluster type' is not set for cluster '"+clusterConfigParam.ClusterName+"'")
 					assert.Empty(t, cfg.ClusterType)
 				})
 			}
@@ -135,7 +135,7 @@ func TestLoadClusterConfig(t *testing.T) {
 					cfg, err := configuration.LoadClusterConfig(term, clusterName)
 
 					// then
-					require.EqualError(t, err, "sandbox command failed: the token in your ksctl.yaml file is missing")
+					require.EqualError(t, err, "ksctl command failed: the token in your ksctl.yaml file is missing")
 					assert.Empty(t, cfg.Token)
 				})
 			}
@@ -153,7 +153,7 @@ func TestLoadClusterConfig(t *testing.T) {
 					cfg, err := configuration.LoadClusterConfig(term, clusterName)
 
 					// then
-					require.EqualError(t, err, "sandbox command failed: The server API is not set for the cluster "+clusterName)
+					require.EqualError(t, err, "ksctl command failed: The server API is not set for the cluster "+clusterName)
 					assert.Empty(t, cfg.ServerAPI)
 				})
 			}
@@ -171,7 +171,7 @@ func TestLoadClusterConfig(t *testing.T) {
 					cfg, err := configuration.LoadClusterConfig(term, clusterName)
 
 					// then
-					require.EqualError(t, err, "sandbox command failed: The server name is not set for the cluster "+clusterName)
+					require.EqualError(t, err, "ksctl command failed: The server name is not set for the cluster "+clusterName)
 					assert.Empty(t, cfg.ServerName)
 				})
 			}
@@ -226,7 +226,7 @@ func TestLoadingClusterConfigWithNonexistentClusterName(t *testing.T) {
 	assert.Contains(t, err.Error(), "the provided cluster-name 'dummy' is not present in your ksctl.yaml file. The available cluster names are")
 	assert.Contains(t, err.Error(), "host")
 	assert.Contains(t, err.Error(), "member-1")
-	assert.Empty(t, cfg.SandboxNamespace)
+	assert.Empty(t, cfg.KubeSawNamespace)
 }
 
 func TestLoad(t *testing.T) {
@@ -238,12 +238,12 @@ func TestLoad(t *testing.T) {
 		configuration.Verbose = true
 
 		// when
-		sandboxUserConfig, path, err := configuration.Load(term)
+		ksctlConfig, path, err := configuration.Load(term)
 
 		// then
 		require.NoError(t, err)
-		expectedConfig := NewSandboxUserConfig(Host(), Member())
-		assert.Equal(t, expectedConfig, sandboxUserConfig)
+		expectedConfig := NewKsctlConfig(Host(), Member())
+		assert.Equal(t, expectedConfig, ksctlConfig)
 		assert.Contains(t, term.Output(), "Using config file")
 		assert.True(t, strings.HasPrefix(path, os.TempDir()))
 
@@ -252,11 +252,11 @@ func TestLoad(t *testing.T) {
 			term := NewFakeTerminal()
 
 			// when
-			sandboxUserConfig, theSamePath, err := configuration.Load(term)
+			ksctlConfig, theSamePath, err := configuration.Load(term)
 
 			// then
 			require.NoError(t, err)
-			assert.Equal(t, expectedConfig, sandboxUserConfig)
+			assert.Equal(t, expectedConfig, ksctlConfig)
 			assert.Contains(t, term.Output(), "Using config file")
 			assert.True(t, strings.HasPrefix(path, os.TempDir()))
 			assert.Equal(t, path, theSamePath)
@@ -268,12 +268,12 @@ func TestLoad(t *testing.T) {
 			SetFileConfig(t, Host(), Member())
 
 			// when
-			sandboxUserConfig, newPath, err := configuration.Load(term)
+			ksctlConfig, newPath, err := configuration.Load(term)
 
 			// then
 			require.NoError(t, err)
-			expectedConfig := NewSandboxUserConfig(Host(), Member())
-			assert.Equal(t, expectedConfig, sandboxUserConfig)
+			expectedConfig := NewKsctlConfig(Host(), Member())
+			assert.Equal(t, expectedConfig, ksctlConfig)
 			assert.Contains(t, term.Output(), "Using config file")
 			assert.True(t, strings.HasPrefix(path, os.TempDir()))
 			assert.NotEqual(t, path, newPath)
@@ -287,12 +287,12 @@ func TestLoad(t *testing.T) {
 		configuration.Verbose = false
 
 		// when
-		sandboxUserConfig, path, err := configuration.Load(term)
+		ksctlConfig, path, err := configuration.Load(term)
 
 		// then
 		require.NoError(t, err)
-		expectedConfig := NewSandboxUserConfig(Host(), Member())
-		assert.Equal(t, expectedConfig, sandboxUserConfig)
+		expectedConfig := NewKsctlConfig(Host(), Member())
+		assert.Equal(t, expectedConfig, ksctlConfig)
 		assert.NotContains(t, term.Output(), "Using config file")
 		assert.True(t, strings.HasPrefix(path, os.TempDir()))
 	})

--- a/pkg/test/config.go
+++ b/pkg/test/config.go
@@ -92,16 +92,16 @@ func WithValues(clusterDef ClusterDefinitionWithName, options ...ConfigOption) C
 	return clusterDef
 }
 
-// NewSandboxUserConfig creates SandboxUserConfig object with the given cluster definitions
-func NewSandboxUserConfig(clusterDefs ...ClusterDefinitionWithName) configuration.SandboxUserConfig {
-	sandboxUserConfig := configuration.SandboxUserConfig{
+// NewKsctlConfig creates KsctlConfig object with the given cluster definitions
+func NewKsctlConfig(clusterDefs ...ClusterDefinitionWithName) configuration.KsctlConfig {
+	ksctlConfig := configuration.KsctlConfig{
 		Name:                     "john",
 		ClusterAccessDefinitions: map[string]configuration.ClusterAccessDefinition{},
 	}
 	for _, clusterDefWithName := range clusterDefs {
-		sandboxUserConfig.ClusterAccessDefinitions[clusterDefWithName.ClusterName] = clusterDefWithName.ClusterAccessDefinition
+		ksctlConfig.ClusterAccessDefinitions[clusterDefWithName.ClusterName] = clusterDefWithName.ClusterAccessDefinition
 	}
-	return sandboxUserConfig
+	return ksctlConfig
 }
 
 // SetFileConfig generates the configuration file to use during a test
@@ -116,8 +116,8 @@ func SetFileConfig(t *testing.T, clusterDefs ...ClusterDefinitionWithName) {
 		configuration.ConfigFileFlag = ""
 	})
 
-	sandboxUserConfig := NewSandboxUserConfig(clusterDefs...)
-	out, err := yaml.Marshal(sandboxUserConfig)
+	ksctlConfig := NewKsctlConfig(clusterDefs...)
+	out, err := yaml.Marshal(ksctlConfig)
 	require.NoError(t, err)
 	err = os.WriteFile(fileName, out, 0600)
 	require.NoError(t, err)


### PR DESCRIPTION
renaming most of the variables, parameters, and references containing "sandbox" word to either KubeSaw or ksctl related names.