### PR TITLE
fix: gock doesn't work with https

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -26,14 +26,14 @@ import (
 func TestNewClientOK(t *testing.T) {
 	// given
 	t.Cleanup(gock.OffAll)
-	gock.New("https://example.com").
+	gock.New("http://example.com").
 		Get("api").
 		Persist().
 		Reply(200).
 		BodyString("{}")
 
 	// when
-	cl, err := client.NewClient("cool-token", "https://example.com")
+	cl, err := client.NewClient("cool-token", "http://example.com")
 
 	// then
 	require.NoError(t, err)

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -42,14 +42,6 @@ func NewFakeClients(t *testing.T, initObjs ...runtime.Object) (clicontext.NewCli
 }
 
 func NewFakeExternalClient(t *testing.T, token string, apiEndpoint string) *rest.RESTClient {
-	// mock request to download a script from GitHub
-	gock.New("https://raw.githubusercontent.com").
-		Get("codeready-toolchain/toolchain-cicd/master/scripts/add-cluster.sh").
-		Persist(). // make sure multiple requests are all handled by Gock
-		Reply(200)
-
-	// gock.Observe(gock.DumpRequest)
-	t.Cleanup(gock.OffAll)
 	cl, err := client.NewRESTClient(token, apiEndpoint)
 	require.NoError(t, err)
 	// override the underlying client's transport with Gock to intercep requests


### PR DESCRIPTION
gock doesn't work with https, so instead of mocking, we were talking to the actual clusters.