### PR TITLE
fix 2.0: use default transport to mock http requests

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -55,6 +55,14 @@ func AddToScheme() error {
 var DefaultNewClient = NewClient
 
 func NewClient(token, apiEndpoint string) (runtimeclient.Client, error) {
+	return NewClientWitTransport(token, apiEndpoint, &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, // nolint: gosec
+		},
+	})
+}
+
+func NewClientWitTransport(token, apiEndpoint string, transport http.RoundTripper) (runtimeclient.Client, error) {
 	if err := AddToScheme(); err != nil {
 		return nil, err
 	}
@@ -63,11 +71,7 @@ func NewClient(token, apiEndpoint string) (runtimeclient.Client, error) {
 		return nil, err
 	}
 
-	cfg.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // nolint: gosec
-		},
-	}
+	cfg.Transport = transport
 	cfg.BearerToken = string(token)
 	cfg.QPS = 40.0
 	cfg.Burst = 50

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -55,14 +55,14 @@ func AddToScheme() error {
 var DefaultNewClient = NewClient
 
 func NewClient(token, apiEndpoint string) (runtimeclient.Client, error) {
-	return NewClientWitTransport(token, apiEndpoint, &http.Transport{
+	return NewClientWithTransport(token, apiEndpoint, &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true, // nolint: gosec
 		},
 	})
 }
 
-func NewClientWitTransport(token, apiEndpoint string, transport http.RoundTripper) (runtimeclient.Client, error) {
+func NewClientWithTransport(token, apiEndpoint string, transport http.RoundTripper) (runtimeclient.Client, error) {
 	if err := AddToScheme(); err != nil {
 		return nil, err
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -3,7 +3,6 @@ package client_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -34,7 +33,7 @@ func TestNewClientOK(t *testing.T) {
 		BodyString("{}")
 
 	// when
-	cl, err := client.NewClientWithTransport("cool-token", "https://example.com", http.DefaultTransport)
+	cl, err := client.NewClientWithTransport("cool-token", "https://example.com", gock.DefaultTransport)
 
 	// then
 	require.NoError(t, err)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -26,14 +26,14 @@ import (
 func TestNewClientOK(t *testing.T) {
 	// given
 	t.Cleanup(gock.OffAll)
-	gock.New("https://example.com").
+	gock.New("https://some-dummy-example.com").
 		Get("api").
 		Persist().
 		Reply(200).
 		BodyString("{}")
 
 	// when
-	cl, err := client.NewClientWithTransport("cool-token", "https://example.com", gock.DefaultTransport)
+	cl, err := client.NewClientWithTransport("cool-token", "https://some-dummy-example.com", gock.DefaultTransport)
 
 	// then
 	require.NoError(t, err)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -26,14 +27,14 @@ import (
 func TestNewClientOK(t *testing.T) {
 	// given
 	t.Cleanup(gock.OffAll)
-	gock.New("http://example.com").
+	gock.New("https://example.com").
 		Get("api").
 		Persist().
 		Reply(200).
 		BodyString("{}")
 
 	// when
-	cl, err := client.NewClient("cool-token", "http://example.com")
+	cl, err := client.NewClientWitTransport("cool-token", "https://example.com", http.DefaultTransport)
 
 	// then
 	require.NoError(t, err)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -34,7 +34,7 @@ func TestNewClientOK(t *testing.T) {
 		BodyString("{}")
 
 	// when
-	cl, err := client.NewClientWitTransport("cool-token", "https://example.com", http.DefaultTransport)
+	cl, err := client.NewClientWithTransport("cool-token", "https://example.com", http.DefaultTransport)
 
 	// then
 	require.NoError(t, err)


### PR DESCRIPTION
gock relies on the default transport that mocks