### PR TITLE
move generating commands under 'ksctl generate' sub-command

### DIFF
--- a/pkg/cmd/adm/adm.go
+++ b/pkg/cmd/adm/adm.go
@@ -22,8 +22,6 @@ func NewAdmCmd() *cobra.Command {
 func registerCommands(admCommand *cobra.Command) {
 	// commands with go runtime client
 	admCommand.AddCommand(NewRestartCmd())
-	admCommand.AddCommand(NewSetupCmd())
-	admCommand.AddCommand(NewGenerateCliConfigsCmd())
 	admCommand.AddCommand(NewUnregisterMemberCmd())
 	admCommand.AddCommand(NewMustGatherNamespaceCmd())
 

--- a/pkg/cmd/generate/admin-manifests.go
+++ b/pkg/cmd/generate/admin-manifests.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"os"
@@ -19,12 +19,12 @@ type setupFlags struct {
 	singleCluster                                         bool
 }
 
-func NewSetupCmd() *cobra.Command {
+func NewAdminManifestsCmd() *cobra.Command {
 	f := setupFlags{}
 	command := &cobra.Command{
-		Use: "setup --kubesaw-admins=<path-to-kubesaw-admins-file> --out-dir <path-to-out-dir>",
-		Example: `ksctl adm setup ./path/to/kubesaw.openshiftapps.com/kubesaw-admins.yaml --out-dir ./components/auth/kubesaw-production
-ksctl adm setup ./path/to/kubesaw-stage.openshiftapps.com/kubesaw-admins.yaml --out-dir ./components/auth/kubesaw-staging -s`,
+		Use: "admin-manifests --kubesaw-admins=<path-to-kubesaw-admins-file> --out-dir <path-to-out-dir>",
+		Example: `ksctl generate admin-manifests ./path/to/kubesaw.openshiftapps.com/kubesaw-admins.yaml --out-dir ./components/auth/kubesaw-production
+ksctl generate admin-manifests ./path/to/kubesaw-stage.openshiftapps.com/kubesaw-admins.yaml --out-dir ./components/auth/kubesaw-staging -s`,
 		Short: "Generates user-management manifests",
 		Long:  `Reads the kubesaw-admins.yaml file and based on the content it generates user-management RBAC and manifests.`,
 		Args:  cobra.ExactArgs(0),

--- a/pkg/cmd/generate/admin-manifests_test.go
+++ b/pkg/cmd/generate/admin-manifests_test.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"fmt"

--- a/pkg/cmd/generate/assertion_test.go
+++ b/pkg/cmd/generate/assertion_test.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"encoding/json"

--- a/pkg/cmd/generate/cli_configs.go
+++ b/pkg/cmd/generate/cli_configs.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"context"
@@ -33,10 +33,10 @@ type generateFlags struct {
 	kubeconfigs               []string
 }
 
-func NewGenerateCliConfigsCmd() *cobra.Command {
+func NewCliConfigsCmd() *cobra.Command {
 	f := generateFlags{}
 	command := &cobra.Command{
-		Use:   "generate-cli-configs --kubesaw-admins=<path-to-kubesaw-admins-file>",
+		Use:   "cli-configs --kubesaw-admins=<path-to-kubesaw-admins-file>",
 		Short: "Generate ksctl.yaml files",
 		Long:  `Generate ksctl.yaml files, that is used by ksctl, for every ServiceAccount defined in the given kubesaw-admins.yaml file`,
 		Args:  cobra.ExactArgs(0),

--- a/pkg/cmd/generate/cli_configs_test.go
+++ b/pkg/cmd/generate/cli_configs_test.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"encoding/json"

--- a/pkg/cmd/generate/cluster.go
+++ b/pkg/cmd/generate/cluster.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"github.com/kubesaw/ksctl/pkg/configuration"

--- a/pkg/cmd/generate/cluster_test.go
+++ b/pkg/cmd/generate/cluster_test.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"fmt"

--- a/pkg/cmd/generate/generate.go
+++ b/pkg/cmd/generate/generate.go
@@ -1,0 +1,20 @@
+package generate
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewGenerateCmd() *cobra.Command {
+	admCommand := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate Commands",
+		Long:  `Actions for generating manifests and files.`,
+	}
+	registerCommands(admCommand)
+	return admCommand
+}
+
+func registerCommands(admCommand *cobra.Command) {
+	admCommand.AddCommand(NewAdminManifestsCmd())
+	admCommand.AddCommand(NewCliConfigsCmd())
+}

--- a/pkg/cmd/generate/mock_test.go
+++ b/pkg/cmd/generate/mock_test.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"fmt"

--- a/pkg/cmd/generate/permissions.go
+++ b/pkg/cmd/generate/permissions.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"fmt"

--- a/pkg/cmd/generate/permissions_test.go
+++ b/pkg/cmd/generate/permissions_test.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"fmt"

--- a/pkg/cmd/generate/roles_manager.go
+++ b/pkg/cmd/generate/roles_manager.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"fmt"

--- a/pkg/cmd/generate/roles_manager_test.go
+++ b/pkg/cmd/generate/roles_manager_test.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"testing"

--- a/pkg/cmd/generate/util.go
+++ b/pkg/cmd/generate/util.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"fmt"

--- a/pkg/cmd/generate/util_test.go
+++ b/pkg/cmd/generate/util_test.go
@@ -1,4 +1,4 @@
-package adm
+package generate
 
 import (
 	"fmt"

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/kubesaw/ksctl/pkg/cmd/adm"
+	"github.com/kubesaw/ksctl/pkg/cmd/generate"
 	"github.com/kubesaw/ksctl/pkg/configuration"
 	"github.com/kubesaw/ksctl/pkg/version"
 	"github.com/spf13/cobra"
@@ -56,6 +57,7 @@ func init() {
 
 	// administrative commands
 	rootCmd.AddCommand(adm.NewAdmCmd())
+	rootCmd.AddCommand(generate.NewGenerateCmd())
 
 	// also, by default, we're configuring the underlying http.Client to accept insecured connections.
 	// but gopkg.in/h2non/gock.v1 may change the client's Transport to intercept the requests.


### PR DESCRIPTION
* create `ksctl generate` sub-command
* move & rename `ksctl adm generate-cli-configs` into `ksctl generate cli-configs`
* move & rename `ksctl adm setup` into `ksctl generate admin-manifests`
* move other related `adm/setup_*.go` files to the folder `generate/` and drop the `setup_` prefix