### PR TITLE
config: force user/identity manifest generation

### DIFF
--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -120,7 +120,9 @@ func TestGetKubeSawAdmins(t *testing.T) {
 	for _, user := range kubeSawAdmins.Users {
 		assert.NotEmpty(t, user.Name)
 		assert.NotEmpty(t, user.ID)
-		verifyNamespacePermissions(t, user.Name, user.PermissionsPerClusterType)
+		if !user.AllClusters {
+			verifyNamespacePermissions(t, user.Name, user.PermissionsPerClusterType)
+		}
 	}
 }
 

--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -120,7 +120,9 @@ func TestGetKubeSawAdmins(t *testing.T) {
 	for _, user := range kubeSawAdmins.Users {
 		assert.NotEmpty(t, user.Name)
 		assert.NotEmpty(t, user.ID)
-		if !user.AllClusters {
+		if len(user.PermissionsPerClusterType) == 0 {
+			assert.True(t, user.AllClusters)
+		} else {
 			verifyNamespacePermissions(t, user.Name, user.PermissionsPerClusterType)
 		}
 	}

--- a/pkg/assets/sandbox_config.go
+++ b/pkg/assets/sandbox_config.go
@@ -29,8 +29,9 @@ type ServiceAccount struct {
 type User struct {
 	Name                      string   `yaml:"name"`
 	ID                        []string `yaml:"id"`
+	AllClusters               bool     `yaml:"allClusters,omitempty"` // force user and identity manifest generation on all clusters, even if no permissions are specified
 	Groups                    []string `yaml:"groups"`
-	PermissionsPerClusterType `yaml:",inline"`
+	PermissionsPerClusterType `yaml:",inline,omitempty"`
 }
 
 type PermissionsPerClusterType map[string]PermissionBindings

--- a/pkg/cmd/generate/admin-manifests_test.go
+++ b/pkg/cmd/generate/admin-manifests_test.go
@@ -35,10 +35,10 @@ func TestAdminManifests(t *testing.T) {
 				HostRoleBindings("toolchain-host-operator", Role("restart-deployment"), ClusterRole("edit")),
 				MemberRoleBindings("toolchain-member-operator", Role("restart-deployment"), ClusterRole("edit")))),
 		Users(
-			User("john-user", []string{"12345"}, "crtadmins-view",
+			User("john-user", []string{"12345"}, false, "crtadmins-view",
 				HostRoleBindings("toolchain-host-operator", Role("register-cluster"), ClusterRole("edit")),
 				MemberRoleBindings("toolchain-member-operator", Role("register-cluster"), ClusterRole("edit"))),
-			User("bob-crtadmin", []string{"67890"}, "crtadmins-exec",
+			User("bob-crtadmin", []string{"67890"}, false, "crtadmins-exec",
 				HostRoleBindings("toolchain-host-operator", Role("restart-deployment"), ClusterRole("admin")),
 				MemberRoleBindings("toolchain-member-operator", Role("restart-deployment"), ClusterRole("admin")))))
 

--- a/pkg/cmd/generate/permissions.go
+++ b/pkg/cmd/generate/permissions.go
@@ -25,7 +25,7 @@ type newSubjectFunc func(ctx *clusterContext, objsCache objectsCache, subjectBas
 // ensurePermissions creates/updates Subject, Role, and RoleBinding for all permissions defined for the cluster type
 func (m *permissionsManager) ensurePermissions(ctx *clusterContext, roleBindingsPerClusterType assets.PermissionsPerClusterType) error {
 	// check if there are any permissions set for this cluster type
-	if _, ok := roleBindingsPerClusterType[ctx.clusterType.String()]; !ok {
+	if _, found := roleBindingsPerClusterType[ctx.clusterType.String()]; !found {
 		return nil
 	}
 

--- a/pkg/test/environment_config.go
+++ b/pkg/test/environment_config.go
@@ -132,7 +132,7 @@ func Users(userCreators ...UserCreator) []assets.User {
 	return users
 }
 
-func User(name string, IDs []string, group string, permissions ...PermissionsPerClusterTypeModifier) UserCreator {
+func User(name string, IDs []string, allCluster bool, group string, permissions ...PermissionsPerClusterTypeModifier) UserCreator {
 	return func() assets.User {
 		var groups []string
 		if group != "" {
@@ -142,6 +142,7 @@ func User(name string, IDs []string, group string, permissions ...PermissionsPer
 			Name:                      name,
 			ID:                        IDs,
 			Groups:                    groups,
+			AllClusters:               allCluster,
 			PermissionsPerClusterType: map[string]assets.PermissionBindings{},
 		}
 		for _, addPermissions := range permissions {

--- a/test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml
+++ b/test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml
@@ -214,3 +214,8 @@ users:
     - namespace: second-component
       clusterRoles:
       - view
+
+- name: my-clusteradmin
+  id:
+  - 1234567890
+  allClusters: true


### PR DESCRIPTION
new `allClusters` boolan field in the YAML config files
to force the generation of the user and identity manifests
for users, even if they don't have any permissions.

This happens in case of OCM accounts who need to be
provisioned on all clusters, but whose association with RBAC
groups is managed by OCM.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
