### PR TITLE
add banned-by label to BannedUser CRs

### DIFF
--- a/pkg/test/banneduser.go
+++ b/pkg/test/banneduser.go
@@ -17,9 +17,11 @@ func AssertBannedUser(t *testing.T, fakeClient *test.FakeClient, userSignup *too
 	err := fakeClient.List(context.TODO(), bannedUsers, runtimeclient.InNamespace(userSignup.Namespace))
 	require.NoError(t, err)
 	require.Len(t, bannedUsers.Items, 1)
-	assert.Equal(t, userSignup.Spec.IdentityClaims.Email, bannedUsers.Items[0].Spec.Email)
-	assert.Equal(t, userSignup.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey], bannedUsers.Items[0].Labels[toolchainv1alpha1.BannedUserEmailHashLabelKey])
-	assert.Equal(t, userSignup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey], bannedUsers.Items[0].Labels[toolchainv1alpha1.BannedUserPhoneNumberHashLabelKey])
+	bannedUser := bannedUsers.Items[0]
+	assert.Equal(t, userSignup.Spec.IdentityClaims.Email, bannedUser.Spec.Email)
+	assert.Equal(t, userSignup.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey], bannedUser.Labels[toolchainv1alpha1.BannedUserEmailHashLabelKey])
+	assert.Equal(t, userSignup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey], bannedUser.Labels[toolchainv1alpha1.BannedUserPhoneNumberHashLabelKey])
+	assert.Equal(t, "john", bannedUser.Labels[toolchainv1alpha1.LabelKeyPrefix+"banned-by"])
 }
 
 func AssertNoBannedUser(t *testing.T, fakeClient *test.FakeClient, userSignup *toolchainv1alpha1.UserSignup) {


### PR DESCRIPTION
[KUBESAW-123](https://issues.redhat.com/browse/KUBESAW-123)

add `toolchain.dev.openshift.com/banned-by` label (by reading the name from `ksctl.yaml` file) to BannedUser CRs created by `ksctl ban` command