### PR TITLE
SANDBOX-677 use go-version-file

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
-
-    - name: Checkout code
-      uses: actions/checkout@v4
+        go-version-file: go.mod
 
     - name: Lint
       uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -19,17 +19,17 @@ jobs:
     name: Test with coverage
 
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.20.x
-
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
         fetch-depth: 0
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
 
     - name: Cache dependencies
       uses: actions/cache@v4

--- a/.github/workflows/user-identity-mapper.yml
+++ b/.github/workflows/user-identity-mapper.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   GOPATH: /tmp/go
-  GO_VERSION: 1.20.x
   IMAGE_REGISTRY: quay.io
   REGISTRY_USER: "codeready-toolchain+push"
   REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/user-identity-mapper.yml
+++ b/.github/workflows/user-identity-mapper.yml
@@ -19,15 +19,15 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Cache dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
uses go-version-file instead of go-version. One less place to change when making updates.
Changes order in github action to first checkout code and then install go.

related PRs:
https://github.com/codeready-toolchain/api/pull/434
https://github.com/codeready-toolchain/toolchain-common/pull/415
https://github.com/codeready-toolchain/member-operator/pull/584
https://github.com/codeready-toolchain/registration-service/pull/445
https://github.com/codeready-toolchain/host-operator/pull/1060
https://github.com/codeready-toolchain/toolchain-e2e/pull/1014