### PR TITLE
improve assertions and remove import being imported more than once

### DIFF
--- a/cmd/user-identity-mapper/user_identity_mapper_test.go
+++ b/cmd/user-identity-mapper/user_identity_mapper_test.go
@@ -145,7 +145,7 @@ func TestUserIdentityMapper(t *testing.T) {
 			err := useridentitymapper.CreateUserIdentityMappings(context.TODO(), logger, cl)
 
 			// then
-			assert.EqualError(t, err, "unable to list users: mock error")
+			require.EqualError(t, err, "unable to list users: mock error")
 		})
 
 		t.Run("cannot list identities", func(t *testing.T) {
@@ -164,7 +164,7 @@ func TestUserIdentityMapper(t *testing.T) {
 			err := useridentitymapper.CreateUserIdentityMappings(context.TODO(), logger, cl)
 
 			// then
-			assert.EqualError(t, err, "unable to list identities: mock error")
+			require.EqualError(t, err, "unable to list identities: mock error")
 		})
 
 		t.Run("cannot create user-identity mapping", func(t *testing.T) {
@@ -183,7 +183,7 @@ func TestUserIdentityMapper(t *testing.T) {
 			err := useridentitymapper.CreateUserIdentityMappings(context.TODO(), logger, cl)
 
 			// then
-			assert.EqualError(t, err, `unable to create identity mapping for username "user1" and identity "identity1": mock error`)
+			require.EqualError(t, err, `unable to create identity mapping for username "user1" and identity "identity1": mock error`)
 		})
 	})
 }

--- a/pkg/cmd/generate/util_test.go
+++ b/pkg/cmd/generate/util_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kubesaw/ksctl/pkg/configuration"
 	userv1 "github.com/openshift/api/user/v1"
-	v1 "github.com/openshift/api/user/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -23,7 +22,7 @@ func TestEnsureObject(t *testing.T) {
 		t.Run("for cluster type "+clusterType.String(), func(t *testing.T) {
 
 			t.Run("for User object", func(t *testing.T) {
-				verifyEnsureManifest(t, clusterType, &v1.User{})
+				verifyEnsureManifest(t, clusterType, &userv1.User{})
 			})
 
 			t.Run("for ServiceAccount object", func(t *testing.T) {
@@ -250,7 +249,7 @@ func TestWriteManifests(t *testing.T) {
 	for _, clusterType := range configuration.ClusterTypes {
 		for _, namespace := range []string{"johnspace", "second-namespace", ""} {
 			clusterCtx := newFakeClusterContext(ctx, clusterType.TheOtherType())
-			user, _ := prepareObjects(t, "john", namespace, &v1.User{})
+			user, _ := prepareObjects(t, "john", namespace, &userv1.User{})
 			require.NoError(t, cache.storeObject(clusterCtx, user))
 			sa, _ := prepareObjects(t, "john", namespace, &corev1.ServiceAccount{})
 			require.NoError(t, cache.storeObject(clusterCtx, sa))


### PR DESCRIPTION
# Description
- improve assertions (error assertions "should" use `require` because it will stop running the following tests (what does not happen with `assert`)
- remove import being imported more than once
