### PR TITLE
fix: default kubeconfig priority logic 

### DIFF
--- a/pkg/cmd/adm/register_member.go
+++ b/pkg/cmd/adm/register_member.go
@@ -81,7 +81,12 @@ func NewRegisterMemberCmd() *cobra.Command {
 	}
 
 	defaultKubeConfigPath := ""
-	if home := homedir.HomeDir(); home != "" {
+
+	// first check if KUBECONFIG env variable is set
+	if kubeconfigPath := os.Getenv("KUBECONFIG"); kubeconfigPath != "" {
+		defaultKubeConfigPath = kubeconfigPath
+	} else if home := homedir.HomeDir(); home != "" {
+		// use home kubeconfig if no KUBECONFIG env var was set
 		defaultKubeConfigPath = filepath.Join(home, ".kube", "config")
 	}
 


### PR DESCRIPTION
use KUBECONFIG when present 