### PR TITLE
fix: rely on kubeconfig for the rest client configuration

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -61,21 +61,6 @@ func NewClient(token, apiEndpoint string) (runtimeclient.Client, error) {
 	return NewClientWithTransport(token, apiEndpoint, newTlsVerifySkippingTransport())
 }
 
-func NewClientFromRestConfig(config *rest.Config) (runtimeclient.Client, error) {
-	tc, err := config.TransportConfig()
-	if err != nil {
-		return nil, err
-	}
-	// when specifying the insecure flag with a certificate file the runtime client throws the following error:
-	// 	cannot create client: specifying a root certificates file with the insecure flag is not allowed
-	//
-	// set insecure flag only if certificate file is not present
-	if !tc.HasCA() {
-		config.Insecure = true
-	}
-	return newClientFromRestConfig(config)
-}
-
 func NewClientWithTransport(token, apiEndpoint string, transport http.RoundTripper) (runtimeclient.Client, error) {
 	cfg, err := clientcmd.BuildConfigFromFlags(apiEndpoint, "")
 	if err != nil {
@@ -88,10 +73,10 @@ func NewClientWithTransport(token, apiEndpoint string, transport http.RoundTripp
 	cfg.Burst = 50
 	cfg.Timeout = 60 * time.Second
 
-	return newClientFromRestConfig(cfg)
+	return NewClientFromRestConfig(cfg)
 }
 
-func newClientFromRestConfig(cfg *rest.Config) (runtimeclient.Client, error) {
+func NewClientFromRestConfig(cfg *rest.Config) (runtimeclient.Client, error) {
 	if err := AddToScheme(); err != nil {
 		return nil, err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -62,7 +62,17 @@ func NewClient(token, apiEndpoint string) (runtimeclient.Client, error) {
 }
 
 func NewClientFromRestConfig(config *rest.Config) (runtimeclient.Client, error) {
-	config.Insecure = true
+	tc, err := config.TransportConfig()
+	if err != nil {
+		return nil, err
+	}
+	// when specifying the insecure flag with a certificate file the runtime client throws the following error:
+	// 	cannot create client: specifying a root certificates file with the insecure flag is not allowed
+	//
+	// set insecure flag only if certificate file is not present
+	if !tc.HasCA() {
+		config.Insecure = true
+	}
 	return newClientFromRestConfig(config)
 }
 


### PR DESCRIPTION
It seems like on certain clusters , for example OCP ones created on AWS the register member command fails, it doesn't  work when passing the `--lets-encrypt true` or `--lets-encrypt false` option. 

See for example : https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/codeready-toolchain_toolchain-e2e/1025/pull-ci-codeready-toolchain-toolchain-e2e-master-e2e/1819262049587302400/build-log.txt

the error comes from [client-go/transport/transport.go](https://github.com/kubernetes/client-go/blob/4f1c2e7b9711846cf31255fd709616c66cb3cfea/transport/transport.go#L91) 