### PR TITLE
mark kubeconfig flag required

### DIFF
--- a/pkg/cmd/adm/must_gather_namespace.go
+++ b/pkg/cmd/adm/must_gather_namespace.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	"k8s.io/kubectl/pkg/scheme"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -52,13 +51,9 @@ func NewMustGatherNamespaceCmd() *cobra.Command {
 			return MustGatherNamespace(term, kubeconfig, args[0], destDir)
 		},
 	}
-	defaultKubeconfigPath := ""
-	if home := homedir.HomeDir(); home != "" {
-		defaultKubeconfigPath = filepath.Join(home, ".kube", "config")
-	}
 	cmd.Flags().StringVar(&destDir, "dest-dir", "", "Gather information with a specific local folder to copy to")
 	flags.MustMarkRequired(cmd, "dest-dir")
-	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", defaultKubeconfigPath, "Path to the kubeconfig file (default: "+defaultKubeconfigPath+")")
+	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
 	flags.MustMarkRequired(cmd, "kubeconfig")
 	return cmd
 }

--- a/pkg/cmd/generate/cli_configs.go
+++ b/pkg/cmd/generate/cli_configs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/kubesaw/ksctl/pkg/assets"
@@ -21,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/utils/pointer"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,12 +52,9 @@ func NewCliConfigsCmd() *cobra.Command {
 	command.Flags().StringVarP(&f.outDir, "out-dir", "o", configDirPath, "Directory where generated ksctl.yaml files should be stored")
 	command.Flags().UintVarP(&f.tokenExpirationDays, "token-expiration-days", "e", 365, "Expiration time of the ServiceAccount tokens in days")
 
-	defaultKubeconfigPath := ""
-	if home := homedir.HomeDir(); home != "" {
-		defaultKubeconfigPath = filepath.Join(home, ".kube", "config")
-	}
-	command.Flags().StringSliceVarP(&f.kubeconfigs, "kubeconfig", "k", []string{defaultKubeconfigPath}, "Kubeconfig(s) for managing multiple clusters and the access to them - paths should be comma separated when using multiple of them. "+
+	command.Flags().StringSliceVarP(&f.kubeconfigs, "kubeconfig", "k", nil, "Kubeconfig(s) for managing multiple clusters and the access to them - paths should be comma separated when using multiple of them. "+
 		"In dev mode, the first one has to represent the host cluster.")
+	flags.MustMarkRequired(command, "kubeconfig")
 
 	return command
 }


### PR DESCRIPTION
let's mark the kubeconfig flag as required so it's always provided explicitly and do not load any default kubeconfigs. This should be consistent in all commands where we rely on kubeconfig only