### PR TITLE
fix: sort available cluster names

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/kubesaw/ksctl/pkg/ioutils"
@@ -145,6 +146,7 @@ func getAllClusterNames(config KsctlConfig) []string {
 	for clusterName := range config.ClusterAccessDefinitions {
 		clusterNames = append(clusterNames, utils.CamelCaseToKebabCase(clusterName))
 	}
+	sort.Strings(clusterNames)
 	return clusterNames
 }
 


### PR DESCRIPTION
sort available cluster names to avoid flaky unit tests https://github.com/kubesaw/ksctl/actions/runs/10489485292/job/29054222888