### PR TITLE
increase wait for install timeout

### DIFF
--- a/pkg/cmd/adm/install_operator.go
+++ b/pkg/cmd/adm/install_operator.go
@@ -43,7 +43,7 @@ func NewInstallOperatorCmd() *cobra.Command {
 
 			cl := commonclient.NewApplyClient(kubeClient)
 			ctx := clicontext.NewTerminalContext(term)
-			return installOperator(ctx, commandArgs, args[0], time.Second*60, cl)
+			return installOperator(ctx, commandArgs, args[0], time.Second*180, cl)
 		},
 	}
 

--- a/pkg/cmd/adm/install_operator_test.go
+++ b/pkg/cmd/adm/install_operator_test.go
@@ -51,8 +51,9 @@ func TestInstallOperator(t *testing.T) {
 		}
 		timeout := 1 * time.Second
 		args := installArgs{
-			kubeConfig: kubeconfig,
-			namespace:  namespace,
+			kubeConfig:          kubeconfig,
+			namespace:           namespace,
+			waitForReadyTimeout: timeout,
 		}
 
 		t.Run("install "+operator+" operator is successful", func(t *testing.T) {
@@ -63,7 +64,7 @@ func TestInstallOperator(t *testing.T) {
 			ctx := clicontext.NewTerminalContext(term)
 
 			// when
-			err := installOperator(ctx, args, operator, timeout, commonclient.NewApplyClient(fakeClient))
+			err := installOperator(ctx, args, operator, commonclient.NewApplyClient(fakeClient))
 
 			// then
 			require.NoError(t, err)
@@ -97,7 +98,7 @@ func TestInstallOperator(t *testing.T) {
 			ctx := clicontext.NewTerminalContext(term)
 
 			// when
-			err := installOperator(ctx, args, operator, timeout, commonclient.NewApplyClient(fakeClient))
+			err := installOperator(ctx, args, operator, commonclient.NewApplyClient(fakeClient))
 
 			// then
 			require.ErrorContains(t, err, "failed waiting for catalog source to be ready.")
@@ -117,7 +118,7 @@ func TestInstallOperator(t *testing.T) {
 			ctx := clicontext.NewTerminalContext(term)
 
 			// when
-			err := installOperator(ctx, args, operator, timeout, commonclient.NewApplyClient(fakeClient))
+			err := installOperator(ctx, args, operator, commonclient.NewApplyClient(fakeClient))
 
 			// then
 			require.ErrorContains(t, err, "failed waiting for install plan to be complete.")
@@ -135,9 +136,8 @@ func TestInstallOperator(t *testing.T) {
 			ctx := clicontext.NewTerminalContext(term)
 
 			// when
-			err := installOperator(ctx, installArgs{namespace: namespace},
+			err := installOperator(ctx, installArgs{namespace: namespace, waitForReadyTimeout: 1 * time.Second},
 				operator,
-				1*time.Second,
 				commonclient.NewApplyClient(fakeClient),
 			)
 
@@ -156,7 +156,7 @@ func TestInstallOperator(t *testing.T) {
 			ctx := clicontext.NewTerminalContext(term)
 
 			// when
-			err := installOperator(ctx, args, operator, timeout, commonclient.NewApplyClient(fakeClient))
+			err := installOperator(ctx, args, operator, commonclient.NewApplyClient(fakeClient))
 
 			// then
 			require.NoError(t, err)
@@ -173,9 +173,8 @@ func TestInstallOperator(t *testing.T) {
 			ctx := clicontext.NewTerminalContext(term)
 
 			// when
-			err := installOperator(ctx, installArgs{namespace: "", kubeConfig: kubeconfig}, // we provide no namespace
+			err := installOperator(ctx, installArgs{namespace: "", kubeConfig: kubeconfig, waitForReadyTimeout: timeout}, // we provide no namespace
 				operator,
-				timeout,
 				commonclient.NewApplyClient(fakeClient),
 			)
 			// then
@@ -194,7 +193,6 @@ func TestInstallOperator(t *testing.T) {
 		// when
 		err := installOperator(ctx, installArgs{},
 			"INVALIDOPERATOR",
-			1*time.Second,
 			commonclient.NewApplyClient(fakeClient),
 		)
 
@@ -210,9 +208,8 @@ func TestInstallOperator(t *testing.T) {
 
 		// when
 		operator := "host"
-		err := installOperator(ctx, installArgs{namespace: "toolchain-host-operator"},
+		err := installOperator(ctx, installArgs{namespace: "toolchain-host-operator", waitForReadyTimeout: time.Second * 1},
 			operator,
-			1*time.Second,
 			commonclient.NewApplyClient(fakeClient),
 		)
 


### PR DESCRIPTION
Move timeout to cli args and increase the default timeout.
On crc it fails sometimes since the catalogsource becomes ready later.

```
Installing latest version of the host-operator
/Users/fmuntean/go/src/github.com/codeready-toolchain/toolchain-e2e/build/_output/bin/ksctl adm install-operator host --kubeconfig "/Users/fmuntean/.kube/config" --namespace toolchain-host-21201257 -y

Are you sure that you want to install host in namespace 'toolchain-host-21201257'
===============================
[y/n] -> response: 'y'
Namespace toolchain-host-21201257 created.
Creating CatalogSource host-operator in namespace toolchain-host-21201257.
CatalogSource host-operator created.
waiting for CatalogSource toolchain-host-21201257/host-operator to become ready
...
waiting for CatalogSource toolchain-host-21201257/host-operator to become ready
Error: failed waiting for catalog source to be ready.
``` 