### PR TITLE
skip retrieval of SA Tokens in members to be skipped

### DIFF
--- a/pkg/cmd/generate/cli_configs.go
+++ b/pkg/cmd/generate/cli_configs.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/strings/slices"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -184,6 +185,9 @@ func generateForCluster(ctx *generateContext, clusterType configuration.ClusterT
 	tokenPerSAName := tokenPerSA{}
 
 	for _, sa := range ctx.kubeSawAdmins.ServiceAccounts {
+		if slices.Contains(sa.Selector.SkipMembers, clusterName) {
+			continue
+		}
 		for saClusterType := range sa.PermissionsPerClusterType {
 			if saClusterType != clusterType.String() {
 				continue


### PR DESCRIPTION
Depends on: https://github.com/kubesaw/ksctl/pull/67

The `ksctl generate cli-configs` command will skip fetching a SA token for members where the SA shouldn't be created.