### PR TITLE
update linter config and fix lint issues

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.56.2
+        version: v1.60.3
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,18 +10,17 @@ run:
 
 linters:
   enable:
-  - megacheck
   - gocyclo
   - gofmt
   - revive
   - misspell
   - gosec
+  - gosimple
+  - staticcheck
   presets: # groups of linters. See https://golangci-lint.run/usage/linters/
   - bugs
   - unused
   disable:
-  - golint # deprecated, use 'revive'
-  - scopelint # deprecated, use 'exportloopref'
   - contextcheck # too many false-positives
   - noctx # not needed
 

--- a/pkg/cmd/adm/must_gather_namespace_test.go
+++ b/pkg/cmd/adm/must_gather_namespace_test.go
@@ -94,7 +94,7 @@ func TestMustGatherNamespaceCmd(t *testing.T) {
 func assertFileContents(t *testing.T, destDir string, fileContents map[string]string) {
 	for filename, expectedContents := range fileContents {
 		actualContents, err := os.ReadFile(filepath.Join(destDir, filename))
-		require.NoError(t, err, fmt.Sprintf("'%s' is missing", filename))
+		require.NoError(t, err, "'%s' is missing", filename)
 		assert.Equal(t, expectedContents, string(actualContents))
 	}
 }

--- a/pkg/cmd/generate/cli_configs.go
+++ b/pkg/cmd/generate/cli_configs.go
@@ -30,7 +30,7 @@ type generateFlags struct {
 	kubeSawAdminsFile, outDir string
 	dev                       bool
 	kubeconfigs               []string
-	tokenExpirationDays       uint
+	tokenExpirationDays       int64
 }
 
 func NewCliConfigsCmd() *cobra.Command {
@@ -51,7 +51,7 @@ func NewCliConfigsCmd() *cobra.Command {
 
 	configDirPath := fmt.Sprintf("%s/src/github.com/kubesaw/ksctl/out/config", os.Getenv("GOPATH"))
 	command.Flags().StringVarP(&f.outDir, "out-dir", "o", configDirPath, "Directory where generated ksctl.yaml files should be stored")
-	command.Flags().UintVarP(&f.tokenExpirationDays, "token-expiration-days", "e", 365, "Expiration time of the ServiceAccount tokens in days")
+	command.Flags().Int64VarP(&f.tokenExpirationDays, "token-expiration-days", "e", 365, "Expiration time of the ServiceAccount tokens in days")
 
 	command.Flags().StringSliceVarP(&f.kubeconfigs, "kubeconfig", "k", nil, "Kubeconfig(s) for managing multiple clusters and the access to them - paths should be comma separated when using multiple of them. "+
 		"In dev mode, the first one has to represent the host cluster.")
@@ -161,7 +161,7 @@ type generateContext struct {
 	newRESTClient       NewRESTClientFromConfigFunc
 	kubeSawAdmins       *assets.KubeSawAdmins
 	kubeconfigPaths     []string
-	tokenExpirationDays uint
+	tokenExpirationDays int64
 }
 
 // contains tokens mapped by SA name
@@ -246,7 +246,7 @@ func buildClientFromKubeconfigFiles(ctx *generateContext, API string, kubeconfig
 // NOTE: due to a changes in OpenShift 4.11, tokens are not listed as `secrets` in ServiceAccounts.
 // The recommended solution is to use the TokenRequest API when server version >= 4.11
 // (see https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-notable-technical-changes)
-func GetServiceAccountToken(cl *rest.RESTClient, namespacedName runtimeclient.ObjectKey, tokenExpirationDays uint) (string, error) {
+func GetServiceAccountToken(cl *rest.RESTClient, namespacedName runtimeclient.ObjectKey, tokenExpirationDays int64) (string, error) {
 	tokenRequest := &authv1.TokenRequest{
 		Spec: authv1.TokenRequestSpec{
 			ExpirationSeconds: pointer.Int64(int64(tokenExpirationDays * 24 * 60 * 60)),

--- a/pkg/ioutils/terminal.go
+++ b/pkg/ioutils/terminal.go
@@ -104,7 +104,7 @@ func (t *DefaultTerminal) PrintObject(object runtime.Object, title string) error
 	if err != nil {
 		return errs.Wrapf(err, "unable to unmarshal %+v", object)
 	}
-	t.PrintContextSeparatorWithBodyf(string(result), title)
+	t.PrintContextSeparatorWithBodyf(string(result), "%s", title)
 	return nil
 }
 


### PR DESCRIPTION
```
WARN [lintersdb] The linter "golint" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
WARN [lintersdb] The linter "scopelint" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
WARN [lintersdb] The linter named "megacheck" is deprecated. It has been split into: gosimple, staticcheck, unused.
```

and

```
pkg/ioutils/terminal.go:107:51: printf: non-constant format string in call to (*github.com/kubesaw/ksctl/pkg/ioutils.DefaultTerminal).PrintContextSeparatorWithBodyf (govet)
        t.PrintContextSeparatorWithBodyf(string(result), title)
                                                         ^
pkg/cmd/generate/cli_configs.go:252:42: G115: integer overflow conversion uint -> int64 (gosec)
                        ExpirationSeconds: pointer.Int64(int64(tokenExpirationDays * 24 * 60 * 60)),
                                                              ^
pkg/cmd/adm/must_gather_namespace_test.go:97:3: formatter: remove unnecessary fmt.Sprintf (testifylint)
                require.NoError(t, err, fmt.Sprintf("'%s' is missing", filename))
```
