### PR TITLE
default ServiceAccounts namespace names

### DIFF
--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -110,6 +110,9 @@ func TestGetKubeSawAdmins(t *testing.T) {
 		assert.NotEmpty(t, member.API)
 	}
 
+	assert.Equal(t, "host-sre-namespace", kubeSawAdmins.DefaultServiceAccountsNamespace.Host)
+	assert.Equal(t, "member-sre-namespace", kubeSawAdmins.DefaultServiceAccountsNamespace.Member)
+
 	assert.NotEmpty(t, kubeSawAdmins.ServiceAccounts)
 	for _, sa := range kubeSawAdmins.ServiceAccounts {
 		assert.NotEmpty(t, sa.Name)

--- a/pkg/assets/sandbox_config.go
+++ b/pkg/assets/sandbox_config.go
@@ -1,9 +1,10 @@
 package assets
 
 type KubeSawAdmins struct {
-	Clusters        Clusters         `yaml:"clusters"`
-	ServiceAccounts []ServiceAccount `yaml:"serviceAccounts"`
-	Users           []User           `yaml:"users"`
+	Clusters                        Clusters                        `yaml:"clusters"`
+	ServiceAccounts                 []ServiceAccount                `yaml:"serviceAccounts"`
+	Users                           []User                          `yaml:"users"`
+	DefaultServiceAccountsNamespace DefaultServiceAccountsNamespace `yaml:"defaultServiceAccountsNamespace"`
 }
 
 type Clusters struct {
@@ -22,6 +23,13 @@ type MemberCluster struct {
 
 type ClusterConfig struct {
 	API string `yaml:"api"`
+}
+
+// DefaultServiceAccountsNamespace defines the names of the default namespaces where the ksctl SAs should be created.
+// If not specified, then the names ksctl-host and ksctl-member are used.
+type DefaultServiceAccountsNamespace struct {
+	Host   string `yaml:"host"`
+	Member string `yaml:"member"`
 }
 
 type ServiceAccount struct {

--- a/pkg/cmd/generate/admin-manifests.go
+++ b/pkg/cmd/generate/admin-manifests.go
@@ -68,6 +68,10 @@ func adminManifests(term ioutils.Terminal, files assets.FS, flags adminManifests
 			}
 		}
 	}
+
+	if defaultSAsNamespace(kubeSawAdmins, configuration.Host) == defaultSAsNamespace(kubeSawAdmins, configuration.Member) {
+		return fmt.Errorf("the default ServiceAccounts namespace has the same name for host cluster as for the member clusters (%s), they have to be different", defaultSAsNamespace(kubeSawAdmins, configuration.Host))
+	}
 	err = os.RemoveAll(flags.outDir)
 	if err != nil {
 		return err

--- a/pkg/cmd/generate/admin-manifests_test.go
+++ b/pkg/cmd/generate/admin-manifests_test.go
@@ -43,7 +43,7 @@ func TestAdminManifests(t *testing.T) {
 			User("bob-crtadmin", []string{"67890"}, false, "crtadmins-exec",
 				HostRoleBindings("toolchain-host-operator", Role("restart-deployment"), ClusterRole("admin")),
 				MemberRoleBindings("toolchain-member-operator", Role("restart-deployment"), ClusterRole("admin")))))
-
+	kubeSawAdmins.DefaultServiceAccountsNamespace.Host = "kubesaw-sre-host"
 	kubeSawAdminsContent, err := yaml.Marshal(kubeSawAdmins)
 	require.NoError(t, err)
 
@@ -85,6 +85,9 @@ func TestAdminManifests(t *testing.T) {
 		t.Run("without separateKustomizeComponent set for member2", func(t *testing.T) {
 			// given
 			kubeSawAdmins.Clusters.Members[1].SeparateKustomizeComponent = false
+			t.Cleanup(func() {
+				kubeSawAdmins.Clusters.Members[1].SeparateKustomizeComponent = true
+			})
 			kubeSawAdminsContent, err := yaml.Marshal(kubeSawAdmins)
 			require.NoError(t, err)
 
@@ -184,6 +187,34 @@ func TestAdminManifests(t *testing.T) {
 		// then
 		require.Error(t, err)
 	})
+
+	t.Run("when default SAs namespace names are the same, then fail", func(t *testing.T) {
+		// given
+		kubeSawAdmins.DefaultServiceAccountsNamespace.Host = "kubesaw-sre"
+		kubeSawAdmins.DefaultServiceAccountsNamespace.Member = "kubesaw-sre"
+		t.Cleanup(func() {
+			kubeSawAdmins.DefaultServiceAccountsNamespace.Host = "kubesaw-sre-host"
+			kubeSawAdmins.DefaultServiceAccountsNamespace.Member = ""
+		})
+		kubeSawAdminsContent, err := yaml.Marshal(kubeSawAdmins)
+		require.NoError(t, err)
+
+		configFile := createKubeSawAdminsFile(t, "kubesaw.host.openshiftapps.com", kubeSawAdminsContent)
+		files := newDefaultFiles(t)
+
+		outTempDir, err := os.MkdirTemp("", "admin-manifests-cli-test-")
+		require.NoError(t, err)
+		term := NewFakeTerminalWithResponse("Y")
+		term.Tee(os.Stdout)
+		flags := newAdminManifestsFlags(outDir(outTempDir), kubeSawAdminsFile(configFile))
+
+		// when
+		err = adminManifests(term, files, flags)
+
+		// then
+		require.EqualError(t, err, "the default ServiceAccounts namespace has the same name for host cluster as for the member clusters (kubesaw-sre), they have to be different")
+	})
+
 }
 
 func storeDummySA(t *testing.T, outDir string) {
@@ -232,7 +263,10 @@ func verifyFiles(t *testing.T, flags adminManifestsFlags) {
 }
 
 func verifyServiceAccounts(t *testing.T, outDir, expectedRootDir string, clusterType configuration.ClusterType, roleNs string) {
-	saNs := fmt.Sprintf("sandbox-sre-%s", clusterType)
+	saNs := "kubesaw-sre-host"
+	if clusterType == configuration.Member {
+		saNs = "ksctl-member"
+	}
 
 	if expectedRootDir != "member2" {
 		// john is skipped for member2 (when generated as a separate kustomize component)

--- a/pkg/cmd/generate/cli_configs.go
+++ b/pkg/cmd/generate/cli_configs.go
@@ -171,7 +171,7 @@ func generateForCluster(ctx *generateContext, clusterType configuration.ClusterT
 	ctx.PrintContextSeparatorf("Generating the content of the ksctl.yaml files for %s cluster running at %s", clusterName, clusterSpec.API)
 
 	// find config we can build client for the cluster from
-	externalClient, err := buildClientFromKubeconfigFiles(ctx, clusterSpec.API, ctx.kubeconfigPaths, sandboxSRENamespace(clusterType))
+	externalClient, err := buildClientFromKubeconfigFiles(ctx, clusterSpec.API, ctx.kubeconfigPaths, defaultSAsNamespace(ctx.kubeSawAdmins, clusterType))
 	if err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func generateForCluster(ctx *generateContext, clusterType configuration.ClusterT
 			if saClusterType != clusterType.String() {
 				continue
 			}
-			saNamespace := sandboxSRENamespace(clusterType)
+			saNamespace := defaultSAsNamespace(ctx.kubeSawAdmins, clusterType)
 			if sa.Namespace != "" {
 				saNamespace = sa.Namespace
 			}

--- a/pkg/cmd/generate/cli_configs_test.go
+++ b/pkg/cmd/generate/cli_configs_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/h2non/gock"
+	"github.com/kubesaw/ksctl/pkg/assets"
 	"github.com/kubesaw/ksctl/pkg/client"
 	"github.com/kubesaw/ksctl/pkg/configuration"
 	. "github.com/kubesaw/ksctl/pkg/test"
@@ -40,25 +41,26 @@ func TestGenerateCliConfigs(t *testing.T) {
 				HostRoleBindings("toolchain-host-operator", Role("restart=restart-deployment"), ClusterRole("restart=edit")),
 				MemberRoleBindings("toolchain-member-operator", Role("restart=restart-deployment"), ClusterRole("restart=edit")))),
 		Users())
+	kubeSawAdmins.DefaultServiceAccountsNamespace.Host = "kubesaw-sre-host"
 
 	kubeSawAdminsContent, err := yaml.Marshal(kubeSawAdmins)
 	require.NoError(t, err)
 	kubeconfigFiles := createKubeconfigFiles(t, ksctlKubeconfigContent, ksctlKubeconfigContentMember2)
 
-	setupGockForListServiceAccounts(t, HostServerAPI, configuration.Host)
-	setupGockForListServiceAccounts(t, Member1ServerAPI, configuration.Member)
-	setupGockForListServiceAccounts(t, Member2ServerAPI, configuration.Member)
+	setupGockForListServiceAccounts(t, kubeSawAdmins, HostServerAPI, configuration.Host)
+	setupGockForListServiceAccounts(t, kubeSawAdmins, Member1ServerAPI, configuration.Member)
+	setupGockForListServiceAccounts(t, kubeSawAdmins, Member2ServerAPI, configuration.Member)
 
 	setupGockForServiceAccounts(t, HostServerAPI, 50,
-		newServiceAccount("sandbox-sre-host", "john"),
-		newServiceAccount("sandbox-sre-host", "bob"),
+		newServiceAccount("kubesaw-sre-host", "john"),
+		newServiceAccount("kubesaw-sre-host", "bob"),
 	)
 	setupGockForServiceAccounts(t, Member1ServerAPI, 50,
-		newServiceAccount("sandbox-sre-member", "john"),
-		newServiceAccount("sandbox-sre-member", "bob"),
+		newServiceAccount("ksctl-member", "john"),
+		newServiceAccount("ksctl-member", "bob"),
 	)
 	setupGockForServiceAccounts(t, Member2ServerAPI, 50,
-		newServiceAccount("sandbox-sre-member", "bob"),
+		newServiceAccount("ksctl-member", "bob"),
 	)
 	t.Cleanup(gock.OffAll)
 
@@ -100,6 +102,7 @@ func TestGenerateCliConfigs(t *testing.T) {
 					Sa("bob", "",
 						HostRoleBindings("toolchain-host-operator", Role("restart=restart-deployment"), ClusterRole("restart=edit")))),
 				Users())
+			saInHostOnly.DefaultServiceAccountsNamespace.Host = "kubesaw-sre-host"
 			kubeSawAdminsContent, err := yaml.Marshal(saInHostOnly)
 			require.NoError(t, err)
 			configFile := createKubeSawAdminsFile(t, "kubesaw.host.openshiftapps.com", kubeSawAdminsContent)
@@ -120,10 +123,10 @@ func TestGenerateCliConfigs(t *testing.T) {
 
 		t.Run("in dev mode", func(t *testing.T) {
 			// given
-			setupGockForListServiceAccounts(t, HostServerAPI, configuration.Member)
+			setupGockForListServiceAccounts(t, kubeSawAdmins, HostServerAPI, configuration.Member)
 			setupGockForServiceAccounts(t, HostServerAPI, 50,
-				newServiceAccount("sandbox-sre-member", "john"),
-				newServiceAccount("sandbox-sre-member", "bob"),
+				newServiceAccount("ksctl-member", "john"),
+				newServiceAccount("ksctl-member", "bob"),
 			)
 			tempDir, err := os.MkdirTemp("", "sandbox-sre-out-")
 			require.NoError(t, err)
@@ -153,7 +156,7 @@ func TestGenerateCliConfigs(t *testing.T) {
 			}
 
 			// when
-			_, err := buildClientFromKubeconfigFiles(ctx, "https://dummy.openshift.com", kubeconfigFiles, sandboxSRENamespace(configuration.Host))
+			_, err := buildClientFromKubeconfigFiles(ctx, "https://dummy.openshift.com", kubeconfigFiles, defaultSAsNamespace(kubeSawAdmins, configuration.Host))
 
 			// then
 			require.Error(t, err)
@@ -162,7 +165,7 @@ func TestGenerateCliConfigs(t *testing.T) {
 
 		t.Run("test buildClientFromKubeconfigFiles cannot list service accounts", func(t *testing.T) {
 			// given
-			path := fmt.Sprintf("api/v1/namespaces/%s/serviceaccounts/", sandboxSRENamespace(configuration.Host))
+			path := fmt.Sprintf("api/v1/namespaces/%s/serviceaccounts/", defaultSAsNamespace(kubeSawAdmins, configuration.Host))
 			gock.New("https://dummy.openshift.com").Get(path).Persist().Reply(403)
 			ctx := &generateContext{
 				Terminal:            term,
@@ -173,7 +176,7 @@ func TestGenerateCliConfigs(t *testing.T) {
 			}
 
 			// when
-			_, err := buildClientFromKubeconfigFiles(ctx, "https://dummy.openshift.com", kubeconfigFiles, sandboxSRENamespace(configuration.Host))
+			_, err := buildClientFromKubeconfigFiles(ctx, "https://dummy.openshift.com", kubeconfigFiles, defaultSAsNamespace(kubeSawAdmins, configuration.Host))
 
 			// then
 			require.Error(t, err)
@@ -216,6 +219,7 @@ func TestGenerateCliConfigs(t *testing.T) {
 					Sa("notmocked", "",
 						HostRoleBindings("toolchain-host-operator", Role("install-operator"), ClusterRole("admin")))),
 				Users())
+			saInHostOnly.DefaultServiceAccountsNamespace.Host = "kubesaw-sre-host"
 			kubeSawAdminsContent, err := yaml.Marshal(saInHostOnly)
 			require.NoError(t, err)
 			configFile := createKubeSawAdminsFile(t, "sandbox.host.openshiftapps.com", kubeSawAdminsContent)
@@ -347,14 +351,14 @@ func (a *ksctlConfigAssertion) hasCluster(clusterName, subDomain string, cluster
 	assert.Equal(a.t, fmt.Sprintf("token-secret-for-%s", a.saBaseName), a.ksctlConfig.ClusterAccessDefinitions[clusterName].Token)
 }
 
-func setupGockForListServiceAccounts(t *testing.T, apiEndpoint string, clusterType configuration.ClusterType) {
+func setupGockForListServiceAccounts(t *testing.T, kubeSawAdmins *assets.KubeSawAdmins, apiEndpoint string, clusterType configuration.ClusterType) {
 	resultServiceAccounts := &corev1.ServiceAccountList{
 		TypeMeta: metav1.TypeMeta{},
 		ListMeta: metav1.ListMeta{},
 		Items: []corev1.ServiceAccount{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: sandboxSRENamespace(clusterType),
+					Namespace: defaultSAsNamespace(kubeSawAdmins, clusterType),
 					Name:      clusterType.String(),
 				},
 			},
@@ -362,7 +366,7 @@ func setupGockForListServiceAccounts(t *testing.T, apiEndpoint string, clusterTy
 	}
 	resultServiceAccountsStr, err := json.Marshal(resultServiceAccounts)
 	require.NoError(t, err)
-	path := fmt.Sprintf("api/v1/namespaces/%s/serviceaccounts/", sandboxSRENamespace(clusterType))
+	path := fmt.Sprintf("api/v1/namespaces/%s/serviceaccounts/", defaultSAsNamespace(kubeSawAdmins, clusterType))
 	t.Logf("mocking access to List %s/%s", apiEndpoint, path)
 	gock.New(apiEndpoint).
 		Get(path).

--- a/pkg/cmd/generate/cluster.go
+++ b/pkg/cmd/generate/cluster.go
@@ -57,7 +57,7 @@ func ensureUsers(ctx *clusterContext, objsCache objectsCache) error {
 		}
 		// create the subject if explicitly requested (even if there is no specific permissions)
 		if user.AllClusters {
-			if _, err := m.createSubject(ctx, m.objectsCache, m.subjectBaseName, sandboxSRENamespace(ctx.clusterType), sreLabelsWithUsername(m.subjectBaseName)); err != nil {
+			if _, err := m.createSubject(ctx, m.objectsCache, m.subjectBaseName, defaultSAsNamespace(ctx.kubeSawAdmins, ctx.clusterType), sreLabelsWithUsername(m.subjectBaseName)); err != nil {
 				return err
 			}
 		}

--- a/pkg/cmd/generate/cluster_test.go
+++ b/pkg/cmd/generate/cluster_test.go
@@ -39,7 +39,7 @@ func TestEnsureServiceAccounts(t *testing.T) {
 				require.NoError(t, err)
 
 				roleNs := fmt.Sprintf("toolchain-%s-operator", clusterType)
-				saNs := fmt.Sprintf("sandbox-sre-%s", clusterType)
+				saNs := fmt.Sprintf("ksctl-%s", clusterType)
 
 				inObjectCache(t, ctx.outDir, clusterType.String(), cache).
 					assertSa(saNs, "john").
@@ -119,7 +119,7 @@ func TestEnsureServiceAccounts(t *testing.T) {
 			assertNumberOfRoles(1)
 
 		inObjectCache(t, ctx.outDir, "member-1", cache).
-			assertSa("sandbox-sre-member", "bob").
+			assertSa("ksctl-member", "bob").
 			hasRole("toolchain-member-operator", configuration.Member.AsSuffix("restart-deployment"), configuration.Member.AsSuffix("restart-deployment-bob")).
 			hasNsClusterRole("toolchain-member-operator", "view", configuration.Member.AsSuffix("clusterrole-view-bob"))
 	})

--- a/pkg/cmd/generate/mock_test.go
+++ b/pkg/cmd/generate/mock_test.go
@@ -21,14 +21,12 @@ const (
 
 // files part
 
-func newDefaultFiles(t *testing.T, fakeFiles ...test.FakeFileCreator) assets.FS {
+func newDefaultFiles(t *testing.T) assets.FS {
 	roles := []runtime.Object{installOperatorRole, restartDeploymentRole, editDeploymentRole, registerClusterRole}
 
 	files := test.NewFakeFiles(t,
-		append(fakeFiles,
-			test.FakeTemplate("roles/host.yaml", roles...),
-			test.FakeTemplate("roles/member.yaml", roles...))...,
-	)
+		test.FakeTemplate("roles/host.yaml", roles...),
+		test.FakeTemplate("roles/member.yaml", roles...))
 	return files
 }
 

--- a/pkg/cmd/generate/permissions.go
+++ b/pkg/cmd/generate/permissions.go
@@ -81,7 +81,7 @@ func (m *permissionsManager) ensurePermission(ctx *clusterContext, roleName, tar
 	}
 
 	// ensure that the subject exists
-	subject, err := m.createSubject(ctx, m.objectsCache, m.subjectBaseName, sandboxSRENamespace(ctx.clusterType), sreLabelsWithUsername(m.subjectBaseName))
+	subject, err := m.createSubject(ctx, m.objectsCache, m.subjectBaseName, defaultSAsNamespace(ctx.kubeSawAdmins, ctx.clusterType), sreLabelsWithUsername(m.subjectBaseName))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/generate/permissions_test.go
+++ b/pkg/cmd/generate/permissions_test.go
@@ -39,7 +39,7 @@ func TestEnsurePermissionsInNamespaces(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				roleNs := fmt.Sprintf("toolchain-%s-operator", clusterType)
-				saNs := fmt.Sprintf("sandbox-sre-%s", clusterType)
+				saNs := fmt.Sprintf("ksctl-%s", clusterType)
 
 				inObjectCache(t, ctx.outDir, clusterType.String(), permManager.objectsCache).
 					assertSa(saNs, "john").
@@ -91,15 +91,15 @@ func TestEnsureServiceAccount(t *testing.T) {
 
 		// when
 		subject, err := ensureServiceAccount("")(
-			ctx, cache, "john", "sandbox-sre-host", labels)
+			ctx, cache, "john", "ksctl-host", labels)
 
 		// then
 		require.NoError(t, err)
 		inObjectCache(t, ctx.outDir, "host", cache).
-			assertSa("sandbox-sre-host", "john")
+			assertSa("ksctl-host", "john")
 		assert.Equal(t, "ServiceAccount", subject.Kind)
 		assert.Equal(t, "john", subject.Name)
-		assert.Equal(t, "sandbox-sre-host", subject.Namespace)
+		assert.Equal(t, "ksctl-host", subject.Namespace)
 	})
 
 	t.Run("create SA in the given namespace", func(t *testing.T) {

--- a/pkg/cmd/generate/util.go
+++ b/pkg/cmd/generate/util.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
+	"github.com/kubesaw/ksctl/pkg/assets"
 	"github.com/kubesaw/ksctl/pkg/configuration"
 	"github.com/kubesaw/ksctl/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -231,10 +232,15 @@ func sreLabels() map[string]string {
 	}
 }
 
-func sandboxSRENamespace(clusterType configuration.ClusterType) string {
-	sandboxSRENamespace := "sandbox-sre-host"
+func defaultSAsNamespace(kubeSawAdmins *assets.KubeSawAdmins, clusterType configuration.ClusterType) string {
 	if clusterType == configuration.Member {
-		sandboxSRENamespace = "sandbox-sre-member"
+		if kubeSawAdmins.DefaultServiceAccountsNamespace.Member != "" {
+			return kubeSawAdmins.DefaultServiceAccountsNamespace.Member
+		}
+		return "ksctl-member"
 	}
-	return sandboxSRENamespace
+	if kubeSawAdmins.DefaultServiceAccountsNamespace.Host != "" {
+		return kubeSawAdmins.DefaultServiceAccountsNamespace.Host
+	}
+	return "ksctl-host"
 }

--- a/test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml
+++ b/test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml
@@ -10,6 +10,10 @@ clusters:
     name: member-3
     separateKustomizeComponent: true
 
+defaultServiceAccountsNamespace:
+  host: host-sre-namespace
+  member: member-sre-namespace
+
 serviceAccounts:
 
 - name: first-admin
@@ -139,7 +143,7 @@ users:
     - namespace: openshift-logging
       clusterRoles:
       - view
-    - namespace: sandbox-sre-host
+    - namespace: host-sre-namespace
       roles:
       - view-secrets
       clusterRoles:
@@ -166,7 +170,7 @@ users:
     - namespace: openshift-logging
       clusterRoles:
       - view
-    - namespace: sandbox-sre-member
+    - namespace: member-sre-namespace
       roles:
       - view-secrets
       clusterRoles:


### PR DESCRIPTION
## DO NOT MERGE YET!!!

[KUBESAW-169](https://issues.redhat.com/browse/KUBESAW-169)

the second part of the effort of dropping all sandbox-related words https://github.com/kubesaw/ksctl/pull/69
This is related to the `sandbox-sre-host` and `sandbox-sre-member` namespaces that are used as the default location of SAs from the kubesaw-admins.yaml file.
This PR introduces new fields to kubesaw-admins.yaml file so the stakeholders can defined their own default namespace names.

