### PR TITLE
docs: running `ksctl generate cli-configs` locally

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -197,6 +197,17 @@ serviceAccounts:
 
 For each ServiceAccount defined in this section, the `ksctl generate cli-configs` generates a separate `ksctl.yaml` file with the corresponding cluster configuration and tokens. As an administrator of the clusters, run this command and distribute securely the generated `ksctl.yaml` files to other team members.
 
+====== Testing the `ksctl generate cli-configs` command locally
+1. Run `make install`
+2. Create `kubesaw-admins.yaml` (as an example, check link:test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml[kubesaw-admins.yaml])
+3. Run `ksctl generate admin-manifests --kubesaw-admins <path>/kubesaw-admins.yaml --out-dir <admin-manifests-out-dir-path>`
+4. Create resources from the `<admin-manifests-out-dir-path>` of the previous command. Please, note that you will need to create some namespaces manually (`oc create ns <namespace-name>`), such as `sandbox-sre-host`, `first-component`, `second-component`, `some-component`, `sandbox-sre-member`, and `crw`, for example.
+- Run `oc apply -k <admin-manifests-out-dir-path>/host`
+- Run `oc apply -k <admin-manifests-out-dir-path>/member`
+- Run `oc apply -k <admin-manifests-out-dir-path>/member-3`
+5. Run `ksctl generate cli-configs -k <kubeconfig-path> -c <path>/kubesaw-admins.yaml`
+
+
 ==== Users
 
 The `ksctl` command can generate  The `users` section contains definition for users, identities, and the permissions granted to them.
@@ -247,13 +258,3 @@ If you need any permissions also in a namespace in host cluster (to be used main
     - namespace: <namespace-name>
     ...
 ```
-
-=== Running `ksctl` locally
-1. Run `make install`
-2. Create `kubesaw-admins.yaml` (as an example, check link:test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml[kubesaw-admins.yaml])
-3. Run `ksctl generate admin-manifests --kubesaw-admins <path>/kubesaw-admins.yaml --out-dir <admin-manifests-out-dir-path>`
-4. Create resources from the `<admin-manifests-out-dir-path>` of the previous command. Please, note that you will need to create some namespaces manually (`oc create ns <namespace-name>`), such as `sandbox-sre-host`, `first-component`, `second-component`, `some-component`, `sandbox-sre-member`, and `crw`, for example.
-- Run `oc apply -k <admin-manifests-out-dir-path>/host`
-- Run `oc apply -k <admin-manifests-out-dir-path>/member`
-- Run `oc apply -k <admin-manifests-out-dir-path>/member-3`
-5. Run `ksctl generate cli-configs -k <kubeconfig-path> -c <path>/kubesaw-admins.yaml`

--- a/README.adoc
+++ b/README.adoc
@@ -247,3 +247,13 @@ If you need any permissions also in a namespace in host cluster (to be used main
     - namespace: <namespace-name>
     ...
 ```
+
+=== Running `ksctl` locally
+1. Run `make install`
+2. Create `kubesaw-admins.yaml` (as an example, check link:test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml[kubesaw-admins.yaml])
+3. Run `ksctl generate admin-manifests --kubesaw-admins <path>/kubesaw-admins.yaml --out-dir <admin-manifests-out-dir-path>`
+4. Create resources from the `<admin-manifests-out-dir-path>` of the previous command. Please, note that you will need to create some namespaces manually (`oc create ns <namespace-name>`), such as `sandbox-sre-host`, `first-component`, `second-component`, `some-component`, `sandbox-sre-member`, and `crw`, for example.
+- Run `oc apply -k <admin-manifests-out-dir-path>/host`
+- Run `oc apply -k <admin-manifests-out-dir-path>/member`
+- Run `oc apply -k <admin-manifests-out-dir-path>/member-3`
+5. Run `ksctl generate cli-configs -k <kubeconfig-path> -c <path>/kubesaw-admins.yaml`


### PR DESCRIPTION
# Description
As mentioned in the slack thread, we were missing the steps to run `ksctl generate cli-configs` locally in our docs