### PR TITLE
flag to provide IdP name for identities

### DIFF
--- a/pkg/cmd/generate/admin-manifests.go
+++ b/pkg/cmd/generate/admin-manifests.go
@@ -16,8 +16,8 @@ import (
 )
 
 type adminManifestsFlags struct {
-	kubeSawAdminsFile, outDir, hostRootDir, memberRootDir string
-	singleCluster                                         bool
+	kubeSawAdminsFile, outDir, hostRootDir, memberRootDir, idpName string
+	singleCluster                                                  bool
 }
 
 func NewAdminManifestsCmd() *cobra.Command {
@@ -39,6 +39,7 @@ ksctl generate admin-manifests ./path/to/kubesaw-stage.openshiftapps.com/kubesaw
 	command.Flags().BoolVarP(&f.singleCluster, "single-cluster", "s", false, "If host and member are deployed to the same cluster. Cannot be used with separateKustomizeComponent set in one of the members.")
 	command.Flags().StringVar(&f.hostRootDir, "host-root-dir", "host", "The root directory name for host manifests")
 	command.Flags().StringVar(&f.memberRootDir, "member-root-dir", "member", "The root directory name for member manifests")
+	command.Flags().StringVar(&f.idpName, "idp-name", "KubeSaw", "Identity provider name to be used in Identity CRs")
 
 	flags.MustMarkRequired(command, "kubesaw-admins")
 	flags.MustMarkRequired(command, "out-dir")

--- a/pkg/cmd/generate/admin-manifests_test.go
+++ b/pkg/cmd/generate/admin-manifests_test.go
@@ -385,6 +385,7 @@ func newAdminManifestsFlags(adminManifestsFlagsOptions ...adminManifestsFlagsOpt
 	flags := adminManifestsFlags{
 		hostRootDir:   "host",
 		memberRootDir: "member",
+		idpName:       "KubeSaw",
 	}
 	for _, applyOption := range adminManifestsFlagsOptions {
 		applyOption(&flags)

--- a/pkg/cmd/generate/assertion_test.go
+++ b/pkg/cmd/generate/assertion_test.go
@@ -306,7 +306,10 @@ func (a *storageAssertionImpl) assertUser(name string) userAssertion {
 }
 
 func (a userAssertion) hasIdentity(ID string) userAssertion {
-	ins := commonidentity.NewIdentityNamingStandard(ID, "DevSandbox")
+	return a.hasIdentityWithIdentityStandard(commonidentity.NewIdentityNamingStandard(ID, "KubeSaw"))
+}
+
+func (a userAssertion) hasIdentityWithIdentityStandard(ins commonidentity.NamingStandard) userAssertion {
 	src := &userv1.Identity{}
 	ins.ApplyToIdentity(src)
 

--- a/pkg/cmd/generate/mock_test.go
+++ b/pkg/cmd/generate/mock_test.go
@@ -59,6 +59,7 @@ func newAdminManifestsContext(t *testing.T, config *assets.KubeSawAdmins, files 
 			outDir:        temp,
 			memberRootDir: "member",
 			hostRootDir:   "host",
+			idpName:       "KubeSaw",
 		},
 	}
 }

--- a/pkg/cmd/generate/permissions.go
+++ b/pkg/cmd/generate/permissions.go
@@ -190,7 +190,7 @@ func ensureUserIdentityAndGroups(IDs []string, groups []string) newSubjectFunc {
 		// Create identities and identity mappings
 		for _, id := range IDs {
 
-			ins := commonidentity.NewIdentityNamingStandard(id, "DevSandbox")
+			ins := commonidentity.NewIdentityNamingStandard(id, ctx.idpName)
 
 			// create identity
 			identity := &userv1.Identity{


### PR DESCRIPTION
The last occurrence of the "Sandbox" word is in the IdP name used for identities. 
This PR changes the default IdP name to "KubeSaw" and adds a flag to override it.

[KUBESAW-181](https://issues.redhat.com/browse/KUBESAW-181)