### PR TITLE
Don't use the deprecated fields in ToolchainCluster.Spec

### DIFF
--- a/pkg/test/toolchaincluster.go
+++ b/pkg/test/toolchaincluster.go
@@ -19,10 +19,8 @@ func NewToolchainCluster(modifiers ...ToolchainClusterModifier) *toolchainv1alph
 			Name:      "member1",
 			Namespace: test.HostOperatorNs,
 		},
-		Spec: toolchainv1alpha1.ToolchainClusterSpec{
+		Status: toolchainv1alpha1.ToolchainClusterStatus{
 			APIEndpoint: "https://api.member.com:6443",
-			CABundle:    "somebundle",
-			SecretRef:   toolchainv1alpha1.LocalSecretReference{},
 		},
 	}
 	for _, modify := range modifiers {


### PR DESCRIPTION
Update to the streamlined version of ToolchainCluster and fix the register member tests to take the new version and workflows into account.

Related PRs:
- api: https://github.com/codeready-toolchain/api/pull/448
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/1094
- member-operator: https://github.com/codeready-toolchain/member-operator/pull/602
- registration-service: https://github.com/codeready-toolchain/registration-service/pull/474
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/1054
- ksctl: https://github.com/kubesaw/ksctl/pull/84