### PR TITLE
Do not add username labels to Identities and Users

### DIFF
--- a/pkg/cmd/generate/assertion_test.go
+++ b/pkg/cmd/generate/assertion_test.go
@@ -291,7 +291,6 @@ type userAssertion struct {
 func (a *storageAssertionImpl) assertUser(name string) userAssertion {
 	expLabels := map[string]string{
 		"provider": "ksctl",
-		"username": name,
 	}
 
 	userObj := &userv1.User{}

--- a/pkg/cmd/generate/cluster.go
+++ b/pkg/cmd/generate/cluster.go
@@ -26,9 +26,10 @@ func ensureServiceAccounts(ctx *clusterContext, objsCache objectsCache) error {
 		}
 
 		pm := &permissionsManager{
-			objectsCache:    objsCache,
-			createSubject:   ensureServiceAccount(saNamespace),
-			subjectBaseName: sa.Name,
+			objectsCache:           objsCache,
+			createSubject:          ensureServiceAccount(saNamespace),
+			subjectBaseName:        sa.Name,
+			objectIsServiceAccount: true,
 		}
 
 		if err := pm.ensurePermissions(ctx, sa.PermissionsPerClusterType); err != nil {
@@ -56,7 +57,7 @@ func ensureUsers(ctx *clusterContext, objsCache objectsCache) error {
 		}
 		// create the subject if explicitly requested (even if there is no specific permissions)
 		if user.AllClusters {
-			if _, err := m.createSubject(ctx, m.objectsCache, m.subjectBaseName, defaultSAsNamespace(ctx.kubeSawAdmins, ctx.clusterType), ksctlLabelsWithUsername(m.subjectBaseName)); err != nil {
+			if _, err := m.createSubject(ctx, m.objectsCache, m.subjectBaseName, defaultSAsNamespace(ctx.kubeSawAdmins, ctx.clusterType), ksctlLabels()); err != nil {
 				return err
 			}
 		}

--- a/pkg/cmd/generate/permissions_test.go
+++ b/pkg/cmd/generate/permissions_test.go
@@ -125,7 +125,6 @@ func TestEnsureServiceAccount(t *testing.T) {
 func TestEnsureUserAndIdentity(t *testing.T) {
 	labels := map[string]string{
 		"provider": "ksctl",
-		"username": "john-crtadmin",
 	}
 	require.NoError(t, client.AddToScheme())
 
@@ -222,8 +221,9 @@ func newPermissionsManager(t *testing.T, clusterType configuration.ClusterType, 
 	cache := objectsCache{}
 
 	return permissionsManager{
-		objectsCache:    cache,
-		subjectBaseName: "john",
-		createSubject:   ensureServiceAccount(""),
+		objectsCache:           cache,
+		subjectBaseName:        "john",
+		createSubject:          ensureServiceAccount(""),
+		objectIsServiceAccount: true,
 	}, clusterCtx
 }


### PR DESCRIPTION
Currently `ksctl generate admin-manifests` generates Identities with a username label. Which doesn't work for non DNS compliant usernames. For example usernames with `+`. Such usernames are allowed in OpenShift but can't be used in labels.

This PR still keeps the label for Service Accounts though. Something we should/can fix later.