### PR TITLE
KUBESAW-250: Updating GolangCiLint to v1.63.1

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.60.3
+        version: v1.63.1
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose


### PR DESCRIPTION
Updating the GolangciLint to v1.63.1 across all repos fix the linter error which were caught as a result of upgrading the linter

Similar PRs

- API - https://github.com/codeready-toolchain/api/pull/454
- Toolchain-common - https://github.com/codeready-toolchain/toolchain-common/pull/442
- Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1116
- Member-Operator - https://github.com/codeready-toolchain/member-operator/pull/612
- Toolchain E2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1092
- Registration-Service - https://github.com/codeready-toolchain/registration-service/pull/491