### PR TITLE
Define a role for unregister-member command and delete the referenced secret when unregistering the member

### DIFF
--- a/pkg/cmd/adm/unregister_member_test.go
+++ b/pkg/cmd/adm/unregister_member_test.go
@@ -4,17 +4,26 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	clicontext "github.com/kubesaw/ksctl/pkg/context"
 	. "github.com/kubesaw/ksctl/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestUnregisterMemberWhenAnswerIsY(t *testing.T) {
 	// given
-	toolchainCluster := NewToolchainCluster(ToolchainClusterName("member-cool-server.com"))
+	toolchainCluster := NewToolchainCluster(ToolchainClusterName("member-cool-server.com"), ReferencedSecret("member-cool-server-creds"))
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "member-cool-server-creds",
+			Namespace: test.HostOperatorNs,
+		},
+	}
 
-	newClient, fakeClient := NewFakeClients(t, toolchainCluster)
+	newClient, fakeClient := NewFakeClients(t, toolchainCluster, secret)
 
 	SetFileConfig(t, Host(), Member())
 	term := NewFakeTerminalWithResponse("y")
@@ -37,9 +46,15 @@ func TestUnregisterMemberWhenAnswerIsY(t *testing.T) {
 
 func TestUnregisterMemberWhenRestartError(t *testing.T) {
 	// given
-	toolchainCluster := NewToolchainCluster(ToolchainClusterName("member-cool-server.com"))
+	toolchainCluster := NewToolchainCluster(ToolchainClusterName("member-cool-server.com"), ReferencedSecret("member-cool-server-creds"))
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "member-cool-server-creds",
+			Namespace: test.HostOperatorNs,
+		},
+	}
 
-	newClient, _ := NewFakeClients(t, toolchainCluster)
+	newClient, _ := NewFakeClients(t, toolchainCluster, secret)
 
 	SetFileConfig(t, Host(), Member())
 	term := NewFakeTerminalWithResponse("y")
@@ -56,9 +71,15 @@ func TestUnregisterMemberWhenRestartError(t *testing.T) {
 
 func TestUnregisterMemberCallsRestart(t *testing.T) {
 	// given
-	toolchainCluster := NewToolchainCluster(ToolchainClusterName("member-cool-server.com"))
+	toolchainCluster := NewToolchainCluster(ToolchainClusterName("member-cool-server.com"), ReferencedSecret("member-cool-server-creds"))
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "member-cool-server-creds",
+			Namespace: test.HostOperatorNs,
+		},
+	}
 
-	newClient, _ := NewFakeClients(t, toolchainCluster)
+	newClient, _ := NewFakeClients(t, toolchainCluster, secret)
 
 	SetFileConfig(t, Host(), Member())
 	term := NewFakeTerminalWithResponse("y")
@@ -77,8 +98,15 @@ func TestUnregisterMemberCallsRestart(t *testing.T) {
 
 func TestUnregisterMemberWhenAnswerIsN(t *testing.T) {
 	// given
-	toolchainCluster := NewToolchainCluster(ToolchainClusterName("member-cool-server.com"))
-	newClient, fakeClient := NewFakeClients(t, toolchainCluster)
+	toolchainCluster := NewToolchainCluster(ToolchainClusterName("member-cool-server.com"), ReferencedSecret("member-cool-server-creds"))
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "member-cool-server-creds",
+			Namespace: test.HostOperatorNs,
+		},
+	}
+
+	newClient, fakeClient := NewFakeClients(t, toolchainCluster, secret)
 	SetFileConfig(t, Host(), Member())
 	term := NewFakeTerminalWithResponse("n")
 	ctx := clicontext.NewCommandContext(term, newClient)

--- a/pkg/test/toolchaincluster.go
+++ b/pkg/test/toolchaincluster.go
@@ -49,3 +49,9 @@ func ToolchainClusterName(name string) ToolchainClusterModifier {
 		toolchainCluster.Name = name
 	}
 }
+
+func ReferencedSecret(name string) ToolchainClusterModifier {
+	return func(toolchainCluster *toolchainv1alpha1.ToolchainCluster) {
+		toolchainCluster.Spec.SecretRef.Name = name
+	}
+}

--- a/resources/roles/host.yaml
+++ b/resources/roles/host.yaml
@@ -262,4 +262,24 @@ objects:
     - "get"
     - "list"
     - "patch"
-    - "update"
+- kind: Role
+  apiVersion: rbac.authorization.k8s.io/v1
+  metadata:
+    name: unregister-member
+    labels:
+      provider: ksctl
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - "secrets"
+    verbs:
+    - "get"
+    - "delete"
+  - apiGroups:
+    - toolchain.dev.openshift.com
+    resources:
+    - "toolchainclusters"
+    verbs:
+    - "get"
+    - "delete"


### PR DESCRIPTION
This is a simple PR to also delete the secret together with the `ToolchainCluster` resource when unregistering the member.