### PR TITLE
fix: unregister-member deletes secret & has needed permissions

### DIFF
--- a/pkg/cmd/adm/unregister_member.go
+++ b/pkg/cmd/adm/unregister_member.go
@@ -66,6 +66,7 @@ func UnregisterMemberCluster(ctx *clicontext.CommandContext, clusterName string,
 		if !errors.IsNotFound(err) {
 			return err
 		}
+		ctx.Printlnf("\nThe referenced ToolchainCluster secret %s, is not present.", toolchainCluster.Spec.SecretRef.Name)
 	} else {
 		ctx.Printlnf("\nDeleting the ToolchainCluster secret %s...", toolchainCluster.Spec.SecretRef.Name)
 		if err := hostClusterClient.Delete(context.TODO(), tcSecret); err != nil {

--- a/pkg/cmd/adm/unregister_member_test.go
+++ b/pkg/cmd/adm/unregister_member_test.go
@@ -62,6 +62,7 @@ func TestUnregisterMemberWhenSecretIsMissing(t *testing.T) {
 	// then
 	require.NoError(t, err)
 	AssertToolchainClusterDoesNotExist(t, fakeClient, toolchainCluster)
+	assert.Contains(t, term.Output(), "The referenced ToolchainCluster secret member-cool-server.com-secret, is not present.")
 	assert.NotContains(t, term.Output(), "cool-token")
 }
 

--- a/pkg/test/toolchaincluster.go
+++ b/pkg/test/toolchaincluster.go
@@ -6,6 +6,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,11 @@ func NewToolchainCluster(modifiers ...ToolchainClusterModifier) *toolchainv1alph
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "member1",
 			Namespace: test.HostOperatorNs,
+		},
+		Spec: toolchainv1alpha1.ToolchainClusterSpec{
+			SecretRef: toolchainv1alpha1.LocalSecretReference{
+				Name: "member1-secret",
+			},
 		},
 		Status: toolchainv1alpha1.ToolchainClusterStatus{
 			APIEndpoint: "https://api.member.com:6443",
@@ -33,6 +39,9 @@ func AssertToolchainClusterDoesNotExist(t *testing.T, fakeClient *test.FakeClien
 	deletedCluster := &toolchainv1alpha1.ToolchainCluster{}
 	err := fakeClient.Get(context.TODO(), test.NamespacedName(toolchainCluster.Namespace, toolchainCluster.Name), deletedCluster)
 	require.True(t, apierrors.IsNotFound(err), "the ToolchainCluster should be deleted")
+
+	err = fakeClient.Get(context.TODO(), test.NamespacedName(toolchainCluster.Namespace, toolchainCluster.Spec.SecretRef.Name), &v1.Secret{})
+	require.True(t, apierrors.IsNotFound(err), "the ToolchainCluster secret should be deleted")
 }
 
 func AssertToolchainClusterSpec(t *testing.T, fakeClient *test.FakeClient, expectedToolchainCluster *toolchainv1alpha1.ToolchainCluster) {
@@ -47,5 +56,6 @@ type ToolchainClusterModifier func(toolchainCluster *toolchainv1alpha1.Toolchain
 func ToolchainClusterName(name string) ToolchainClusterModifier {
 	return func(toolchainCluster *toolchainv1alpha1.ToolchainCluster) {
 		toolchainCluster.Name = name
+		toolchainCluster.Spec.SecretRef.Name = name + "-secret"
 	}
 }

--- a/resources/roles/host.yaml
+++ b/resources/roles/host.yaml
@@ -263,3 +263,27 @@ objects:
     - "list"
     - "patch"
     - "update"
+
+- kind: Role
+  apiVersion: rbac.authorization.k8s.io/v1
+  metadata:
+    name: unregister-member
+    labels:
+      provider: ksctl
+  rules:
+  - apiGroups:
+    - toolchain.dev.openshift.com
+    resources:
+    - "toolchainclusters"
+    verbs:
+    - "get"
+    - "list"
+    - "delete"
+  - apiGroups:
+    - ""
+    resources:
+    - "secrets"
+    verbs:
+    - "get"
+    - "list"
+    - "delete"


### PR DESCRIPTION
[KUBESAW-247](https://issues.redhat.com/browse/KUBESAW-247)
unregister-member should delete also the ToolchainCluster secret.
the role defines the needed permissions 