### PR TITLE
clean unnecessary copy

### DIFF
--- a/pkg/cmd/adm/restart.go
+++ b/pkg/cmd/adm/restart.go
@@ -177,7 +177,6 @@ func deleteDeploymentPods(ctx *clicontext.CommandContext, cl runtimeclient.Clien
 
 	//delete pods
 	for _, pod := range pods.Items {
-		pod := pod // TODO We won't need it after upgrading to go 1.22: https://go.dev/blog/loopvar-preview
 		ctx.Printlnf("Deleting pod: %s", pod.Name)
 		if err := cl.Delete(ctx, &pod); err != nil {
 			return err


### PR DESCRIPTION
# Description
- clean unnecessary copy. With go 1.22, we do not need it. For more info, check https://go.dev/blog/loopvar-preview

- https://github.com/codeready-toolchain/toolchain-e2e/pull/1133
- https://github.com/codeready-toolchain/member-operator/pull/641
- https://github.com/codeready-toolchain/host-operator/pull/1157
- https://github.com/codeready-toolchain/toolchain-common/pull/469
- was pr 149