### PR TITLE
chore(build): migrate to golangci-lint@v2 and golangci-lint-action@v7

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -24,9 +24,9 @@ jobs:
         go-version-file: go.mod
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
-        version: v1.63.1
+        version: v2.0.2
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,33 +1,62 @@
-run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
-
-
+version: "2"
 linters:
   enable:
-  - gocyclo
-  - gofmt
-  - revive
-  - misspell
-  - gosec
-  - gosimple
-  - staticcheck
-  presets: # groups of linters. See https://golangci-lint.run/usage/linters/
-  - bugs
-  - unused
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - gocyclo
+    - gosec
+    - gosmopolitan
+    - loggercheck
+    - makezero
+    - misspell
+    - musttag
+    - nilerr
+    - nilnesserr
+    - protogetter
+    - reassign
+    - recvcheck
+    - revive
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - testifylint
+    - unparam
+    - zerologlint
   disable:
-  - contextcheck # too many false-positives
-  - noctx # not needed
-
-# all available settings of specific linters
-linters-settings:
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: true
-  revive:
-    rules:
-    - name: dot-imports
-      disabled: true
+    - contextcheck
+    - noctx
+  settings:
+    revive:
+      rules:
+        - name: dot-imports
+          disabled: true
+    unparam:
+      check-exported: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/cmd/adm/register_member_test.go
+++ b/pkg/cmd/adm/register_member_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/homedir"
 	pointer "k8s.io/utils/ptr"
@@ -746,7 +745,7 @@ func fillStatusWithDetailsAndReadyCondition(t *testing.T, obj *toolchainv1alpha1
 		operatorNamespace = test.HostOperatorNs
 	default:
 		// If we get here, there is a logic error in the test. Let's fail the test unequivocally.
-		assert.Fail(t, "the mock create of ToolchainCluster only works in host operator namespace %s or member operator namespace %s but the creation of toolchain cluster was requested in %s", test.HostOperatorNs, test.MemberOperatorNs, obj.GetNamespace())
+		assert.Fail(t, "the mock create of ToolchainCluster only works in host operator namespace or member operator namespace but the creation of toolchain cluster was requested in another namespace", "host_ns", test.HostOperatorNs, "member_ns", test.MemberOperatorNs, "obj_ns", obj.GetNamespace())
 	}
 	obj.Status = toolchainv1alpha1.ToolchainClusterStatus{
 		APIEndpoint:       "https://cool-server.com",
@@ -771,7 +770,7 @@ func verifyToolchainClusterSecret(t *testing.T, fakeClient *test.FakeClient, saN
 	assert.NotEmpty(t, secret.StringData["kubeconfig"])
 	apiConfig, err := clientcmd.Load([]byte(secret.StringData["kubeconfig"]))
 	require.NoError(t, err)
-	require.False(t, api.IsConfigEmpty(apiConfig))
+	require.False(t, clientcmdapi.IsConfigEmpty(apiConfig))
 	assert.Equal(t, "https://cool-server.com", apiConfig.Clusters["cluster"].Server)
 	assert.False(t, apiConfig.Clusters["cluster"].InsecureSkipTLSVerify) // by default the insecure flag is not being set
 	assert.Equal(t, "cluster", apiConfig.Contexts["ctx"].Cluster)

--- a/pkg/cmd/generate/util_test.go
+++ b/pkg/cmd/generate/util_test.go
@@ -159,7 +159,7 @@ func verifyEnsureManifest(t *testing.T, clusterType configuration.ClusterType, o
 					t.Run("single-cluster mode enabled", func(t *testing.T) {
 						// given
 						ctx := newAdminManifestsContextWithDefaultFiles(t, nil)
-						ctx.adminManifestsFlags.singleCluster = true
+						ctx.singleCluster = true
 
 						t.Run("update after move to base", func(t *testing.T) {
 							// given

--- a/pkg/test/fake_terminal.go
+++ b/pkg/test/fake_terminal.go
@@ -32,7 +32,7 @@ func NewFakeTerminal() *FakeTerminal {
 // Usage: `Tee(os.Stdout)` to see in the console what's record in this terminal during the tests
 // Note: it should be configured at the beginning of a test
 func (t *FakeTerminal) Tee(out io.Writer) {
-	t.Terminal = ioutils.NewTerminal(t.Terminal.InOrStdin, func() io.Writer {
+	t.Terminal = ioutils.NewTerminal(t.InOrStdin, func() io.Writer {
 		return io.MultiWriter(t.out, out)
 	})
 }


### PR DESCRIPTION
upgraded `.golangci.yml` with `golangci-lint migrate`

include fixes suggested by `golangci-lint run -c ./.golangci.yml`

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
