### PR TITLE
implement the check-banned command

### DIFF
--- a/pkg/cmd/check_banned.go
+++ b/pkg/cmd/check_banned.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/banneduser"
+	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
+	"github.com/kubesaw/ksctl/pkg/client"
+	clicontext "github.com/kubesaw/ksctl/pkg/context"
+	"github.com/kubesaw/ksctl/pkg/ioutils"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewCheckBannedCommand() *cobra.Command {
+	var mur string
+	var signup string
+	var email string
+
+	command := &cobra.Command{
+		Use:   "check-banned [--mur|-m <mur-name>] | [--signup|-s <signup-name>] | [--email|-s <email>]",
+		Short: "Unban the user so that they can use the platform again",
+		Long:  "Unban the user that previously registered with the provided email so that they can start using the platform again.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			term := ioutils.NewTerminal(cmd.InOrStdin, cmd.OutOrStdout)
+			ctx := clicontext.NewCommandContext(term, client.DefaultNewClient)
+			return CheckBanned(ctx, mur, signup, email)
+		},
+	}
+	command.Flags().StringVarP(&mur, "mur", "m", "", "the name of the master user record to check the banned status of")
+	command.Flags().StringVarP(&signup, "signup", "s", "", "the name of the signup to check the banned status of")
+	command.Flags().StringVarP(&email, "email", "e", "", "the email of the user to check the banned status of")
+
+	return command
+}
+
+func CheckBanned(ctx *clicontext.CommandContext, mur string, signup string, email string) error {
+	if !validateCheckBannedInput(mur, signup, email) {
+		return fmt.Errorf("exactly 1 of --mur, --signup or --email must be specified")
+	}
+
+	cl, cfg, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if mur != "" {
+		email, err = findEmailByMUR(ctx, cl, mur, cfg.OperatorNamespace)
+	} else if signup != "" {
+		email, err = findEmailByUserSignup(ctx, cl, signup, cfg.OperatorNamespace)
+	}
+	if err != nil {
+		return err
+	}
+
+	if email == "" {
+		ctx.Println("User not found.")
+		return nil
+	}
+
+	emailHash := hash.EncodeString(email)
+	bu, err := banneduser.GetBannedUser(ctx, emailHash, cl, cfg.OperatorNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to find the banned user: %w", err)
+	}
+
+	if bu == nil {
+		ctx.Println("User is NOT banned.")
+	} else {
+		ctx.Println("User is banned.")
+	}
+	return nil
+}
+
+func validateCheckBannedInput(mur, signup, email string) bool {
+	var flagCount int
+
+	if mur != "" {
+		flagCount += 1
+	}
+	if signup != "" {
+		flagCount += 1
+	}
+	if email != "" {
+		flagCount += 1
+	}
+
+	return flagCount == 1
+}
+
+func findEmailByMUR(ctx context.Context, cl runtimeclient.Client, mur, namespace string) (string, error) {
+	obj := &toolchainv1alpha1.MasterUserRecord{}
+	if err := cl.Get(ctx, runtimeclient.ObjectKey{Name: mur, Namespace: namespace}, obj); err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return obj.Spec.PropagatedClaims.Email, nil
+}
+
+func findEmailByUserSignup(ctx context.Context, cl runtimeclient.Client, usersignup, namespace string) (string, error) {
+	obj := &toolchainv1alpha1.UserSignup{}
+	if err := cl.Get(ctx, runtimeclient.ObjectKey{Name: usersignup, Namespace: namespace}, obj); err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return obj.Spec.IdentityClaims.Email, nil
+}

--- a/pkg/cmd/check_banned_test.go
+++ b/pkg/cmd/check_banned_test.go
@@ -1,0 +1,258 @@
+package cmd_test
+
+import (
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/kubesaw/ksctl/pkg/cmd"
+	clicontext "github.com/kubesaw/ksctl/pkg/context"
+	. "github.com/kubesaw/ksctl/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCheckBanned(t *testing.T) {
+	t.Run("fails with wrong number of parameters", func(t *testing.T) {
+		// given
+		newClient, _ := NewFakeClients(t)
+		SetFileConfig(t, Host())
+		term := NewFakeTerminal()
+		ctx := clicontext.NewCommandContext(term, newClient)
+
+		test := func(t *testing.T, mur, signup, email string) {
+			// when
+			err := cmd.CheckBanned(ctx, mur, signup, email)
+
+			// then
+			require.Error(t, err)
+			assert.Equal(t, "exactly 1 of --mur, --signup or --email must be specified", err.Error())
+		}
+
+		t.Run("no parameters", func(t *testing.T) {
+			test(t, "", "", "")
+		})
+		t.Run("mur+signup", func(t *testing.T) {
+			test(t, "mur", "signup", "")
+		})
+		t.Run("mur+email", func(t *testing.T) {
+			test(t, "mur", "", "email")
+		})
+		t.Run("signup+email", func(t *testing.T) {
+			test(t, "", "signup", "email")
+		})
+		t.Run("mur+signup+email", func(t *testing.T) {
+			test(t, "mur", "signup", "email")
+		})
+	})
+	t.Run("finds the banned user by the MUR name", func(t *testing.T) {
+		t.Run("user is banned", func(t *testing.T) {
+			// given
+			mur := &toolchainv1alpha1.MasterUserRecord{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "theUser",
+					Namespace: test.HostOperatorNs,
+				},
+				Spec: toolchainv1alpha1.MasterUserRecordSpec{
+					PropagatedClaims: toolchainv1alpha1.PropagatedClaims{
+						Email: "me@home",
+					},
+				},
+			}
+			bannedUser := &toolchainv1alpha1.BannedUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "arbitrary-name",
+					Namespace: test.HostOperatorNs,
+					Labels: map[string]string{
+						toolchainv1alpha1.BannedUserEmailHashLabelKey: hash.EncodeString("me@home"),
+					},
+				},
+				Spec: toolchainv1alpha1.BannedUserSpec{
+					Email: "me@home",
+				},
+			}
+
+			newClient, _ := NewFakeClients(t, mur, bannedUser)
+			SetFileConfig(t, Host())
+			term := NewFakeTerminal()
+			ctx := clicontext.NewCommandContext(term, newClient)
+
+			// when
+			err := cmd.CheckBanned(ctx, "theUser", "", "")
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, term.Output(), "User is banned.\n")
+		})
+		t.Run("user is not banned", func(t *testing.T) {
+			// given
+			mur := &toolchainv1alpha1.MasterUserRecord{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "theUser",
+					Namespace: test.HostOperatorNs,
+				},
+				Spec: toolchainv1alpha1.MasterUserRecordSpec{
+					PropagatedClaims: toolchainv1alpha1.PropagatedClaims{
+						Email: "me@home",
+					},
+				},
+			}
+
+			newClient, _ := NewFakeClients(t, mur)
+			SetFileConfig(t, Host())
+			term := NewFakeTerminal()
+			ctx := clicontext.NewCommandContext(term, newClient)
+
+			// when
+			err := cmd.CheckBanned(ctx, "theUser", "", "")
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, term.Output(), "User is NOT banned.\n")
+		})
+		t.Run("mur is not found", func(t *testing.T) {
+			// given
+			newClient, _ := NewFakeClients(t)
+			SetFileConfig(t, Host())
+			term := NewFakeTerminal()
+			ctx := clicontext.NewCommandContext(term, newClient)
+
+			// when
+			err := cmd.CheckBanned(ctx, "theUser", "", "")
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, term.Output(), "User not found.\n")
+		})
+	})
+	t.Run("finds the banned user by the UserSignup name", func(t *testing.T) {
+		t.Run("user is banned", func(t *testing.T) {
+			// given
+			signup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "theUser",
+					Namespace: test.HostOperatorNs,
+				},
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
+						PropagatedClaims: toolchainv1alpha1.PropagatedClaims{
+							Email: "me@home",
+						},
+					},
+				},
+			}
+			bannedUser := &toolchainv1alpha1.BannedUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "arbitrary-name",
+					Namespace: test.HostOperatorNs,
+					Labels: map[string]string{
+						toolchainv1alpha1.BannedUserEmailHashLabelKey: hash.EncodeString("me@home"),
+					},
+				},
+				Spec: toolchainv1alpha1.BannedUserSpec{
+					Email: "me@home",
+				},
+			}
+
+			newClient, _ := NewFakeClients(t, signup, bannedUser)
+			SetFileConfig(t, Host())
+			term := NewFakeTerminal()
+			ctx := clicontext.NewCommandContext(term, newClient)
+
+			// when
+			err := cmd.CheckBanned(ctx, "", "theUser", "")
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, term.Output(), "User is banned.\n")
+		})
+		t.Run("user is not banned", func(t *testing.T) {
+			// given
+			signup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "theUser",
+					Namespace: test.HostOperatorNs,
+				},
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
+						PropagatedClaims: toolchainv1alpha1.PropagatedClaims{
+							Email: "me@home",
+						},
+					},
+				},
+			}
+
+			newClient, _ := NewFakeClients(t, signup)
+			SetFileConfig(t, Host())
+			term := NewFakeTerminal()
+			ctx := clicontext.NewCommandContext(term, newClient)
+
+			// when
+			err := cmd.CheckBanned(ctx, "", "theUser", "")
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, term.Output(), "User is NOT banned.\n")
+		})
+		t.Run("usersignup is not found", func(t *testing.T) {
+			// given
+			newClient, _ := NewFakeClients(t)
+			SetFileConfig(t, Host())
+			term := NewFakeTerminal()
+			ctx := clicontext.NewCommandContext(term, newClient)
+
+			// when
+			err := cmd.CheckBanned(ctx, "", "theUser", "")
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, term.Output(), "User not found.\n")
+		})
+	})
+	t.Run("finds the banned user by the email", func(t *testing.T) {
+		t.Run("user is banned", func(t *testing.T) {
+			// given
+			bannedUser := &toolchainv1alpha1.BannedUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "arbitrary-name",
+					Namespace: test.HostOperatorNs,
+					Labels: map[string]string{
+						toolchainv1alpha1.BannedUserEmailHashLabelKey: hash.EncodeString("me@home"),
+					},
+				},
+				Spec: toolchainv1alpha1.BannedUserSpec{
+					Email: "me@home",
+				},
+			}
+
+			newClient, _ := NewFakeClients(t, bannedUser)
+			SetFileConfig(t, Host())
+			term := NewFakeTerminal()
+			ctx := clicontext.NewCommandContext(term, newClient)
+
+			// when
+			err := cmd.CheckBanned(ctx, "", "", "me@home")
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, term.Output(), "User is banned.\n")
+		})
+		t.Run("user is not banned", func(t *testing.T) {
+			// given
+
+			newClient, _ := NewFakeClients(t)
+			SetFileConfig(t, Host())
+			term := NewFakeTerminal()
+			ctx := clicontext.NewCommandContext(term, newClient)
+
+			// when
+			err := cmd.CheckBanned(ctx, "", "", "me@home")
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, term.Output(), "User is NOT banned.\n")
+		})
+	})
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -57,6 +57,7 @@ func init() {
 	rootCmd.AddCommand(NewDisableFeatureCmd())
 	rootCmd.AddCommand(NewEnableFeatureCmd())
 	rootCmd.AddCommand(NewUnbanCommand())
+	rootCmd.AddCommand(NewCheckBannedCommand())
 
 	// administrative commands
 	rootCmd.AddCommand(adm.NewAdmCmd())

--- a/resources/roles/host.yaml
+++ b/resources/roles/host.yaml
@@ -128,6 +128,24 @@ objects:
     - toolchain.dev.openshift.com
     resources:
     - "usersignups"
+    - "masteruserrecords"
+    verbs:
+    - "get"
+    - "list"
+
+- kind: Role
+  apiVersion: rbac.authorization.k8s.io/v1
+  metadata:
+    name: check-banned
+    labels:
+      provider: ksctl
+  rules:
+  - apiGroups:
+    - toolchain.dev.openshift.com
+    resources:
+    - "usersignups"
+    - "masteruserrecords"
+    - "bannedusers"
     verbs:
     - "get"
     - "list"

--- a/test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml
+++ b/test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml
@@ -26,6 +26,7 @@ serviceAccounts:
       - view-secrets
       - deactivate-user
       - ban-user
+      - check-banned
       - promote-user
       - disable-user
       - retarget-user
@@ -52,6 +53,7 @@ serviceAccounts:
       - view-secrets
       - deactivate-user
       - ban-user
+      - check-banned
       - promote-user
       - disable-user
       - retarget-user


### PR DESCRIPTION
This adds a new `check-banned` command that can tell if a user is banned based on either MUR name, UserSignup name or an email.