### PR TITLE
Remove the check-banned role

### DIFF
--- a/resources/roles/host.yaml
+++ b/resources/roles/host.yaml
@@ -133,22 +133,6 @@ objects:
     - "get"
     - "list"
 
-- kind: Role
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    name: check-banned
-    labels:
-      provider: ksctl
-  rules:
-  - apiGroups:
-    - toolchain.dev.openshift.com
-    resources:
-    - "usersignups"
-    - "masteruserrecords"
-    - "bannedusers"
-    verbs:
-    - "get"
-    - "list"
 
 - kind: Role
   apiVersion: rbac.authorization.k8s.io/v1

--- a/test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml
+++ b/test-resources/dummy.openshiftapps.com/kubesaw-admins.yaml
@@ -26,7 +26,6 @@ serviceAccounts:
       - view-secrets
       - deactivate-user
       - ban-user
-      - check-banned
       - promote-user
       - disable-user
       - retarget-user
@@ -53,7 +52,6 @@ serviceAccounts:
       - view-secrets
       - deactivate-user
       - ban-user
-      - check-banned
       - promote-user
       - disable-user
       - retarget-user


### PR DESCRIPTION
Remove the `check-banned` role because all of its permissions are already included in the existing `ban-user` role and, more importantly, in the default `view` role.