### PR TITLE
update to using the SSA-enabled generation of the bundled NSTemplateTiers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/charmbracelet/lipgloss v0.10.0 // indirect
-	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.2 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
@@ -142,3 +142,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/metlos/toolchain-common v0.0.0-20250702122526-cf062f90f967

--- a/go.sum
+++ b/go.sum
@@ -39,12 +39,10 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
-github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
-github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
+github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/codeready-toolchain/api v0.0.0-20250506092100-39b4862e1271 h1:AHrFr/aPuJ4+0zHw4sFXcfMA92kChy12JAPS5bLODlw=
 github.com/codeready-toolchain/api v0.0.0-20250506092100-39b4862e1271/go.mod h1:20258od6i5+jP406Z76YaI2ow/vc7URwsDU2bokpkRE=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250506093954-2b65ad3a2e12 h1:w54sojJJ8PsHZzK1mC+/EUBrQ9F2sC/k7JUVc8LSqK4=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250506093954-2b65ad3a2e12/go.mod h1:TrMvD0sP69wI6Rouzfs7OsOUSj4CGn/ZiIdiDBAFQjk=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -180,6 +178,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/metlos/toolchain-common v0.0.0-20250702122526-cf062f90f967 h1:fIIjmLl4l1NlRPcC9joEitiB/5s19F4cfg1AnxukYEQ=
+github.com/metlos/toolchain-common v0.0.0-20250702122526-cf062f90f967/go.mod h1:mjwK6D+gH299P2CEUgliLEwJs4K+Cx++Bns/8rYkxUU=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/pkg/cmd/generate/nstemplatetiers.go
+++ b/pkg/cmd/generate/nstemplatetiers.go
@@ -75,14 +75,14 @@ func NSTemplateTiers(term ioutils.Terminal, source, outDir, hostNs string) error
 		outDir:                absOutDir,
 		manageOutDirKustomize: true,
 	}
-	err = nstemplatetiers.GenerateTiers(scheme.Scheme, func(toEnsure runtimeclient.Object, canUpdate bool, tierName string) (bool, error) {
+	err = nstemplatetiers.GenerateTiers(scheme.Scheme, func(toEnsure runtimeclient.Object, tierName string) error {
 		if err := setGVK(toEnsure); err != nil {
-			return false, err
+			return err
 		}
 		kind := toEnsure.GetObjectKind().GroupVersionKind().Kind
 		path := filepath.Join(absOutDir, tierName, fmt.Sprintf("%s-%s.yaml", strings.ToLower(kind), toEnsure.GetName()))
 		term.Printlnf("Storing %s with name %s in %s", kind, toEnsure.GetName(), path)
-		return true, writeManifest(ctx, path, toEnsure)
+		return writeManifest(ctx, path, toEnsure)
 	}, hostNs, metadata, templates)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is because of the change in toolchain-common that changed the signature of EnsureObject so that it is usable with the SSA client.

Related PRs:
- toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/486
- https://github.com/codeready-toolchain/host-operator/pull/1185