### PR TITLE
build: switch to toolchain-cicd/govulncheck-action

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,8 +19,8 @@ jobs:
         go-version-file: go.mod
 
     - name: Run govulncheck
-      uses: golang/govulncheck-action@v1
+      uses: codeready-toolchain/toolchain-cicd/govulncheck-action@master
       with:
-        go-version-input: ${{ steps.install-go.outputs.go-version }}
-        go-package: ./...
-        repo-checkout: false
+        go-version-file: go.mod
+        cache: false
+        config: .govulncheck.yaml

--- a/.govulncheck.yaml
+++ b/.govulncheck.yaml
@@ -1,0 +1,20 @@
+ignored-vulnerabilities:
+  # Request smuggling due to acceptance of invalid chunked data in net/http
+  # Standard library
+  # Found in: net/http/internal@go1.22.12
+  # Fixed in: net/http/internal@go1.23.8
+  - id: GO-2025-3563
+    silence-until: 2025-10-02
+    info: https://pkg.go.dev/vuln/GO-2025-3563
+  # Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in syscall
+  # Found in: os@go1.22.12
+  # Fixed in: os@go1.23.10
+  - id: GO-2025-3750
+    silence-until: 2025-10-02
+    info: https://pkg.go.dev/vuln/GO-2025-3750
+  # Sensitive headers not cleared on cross-origin redirect in net/http
+  # Found in: net/http@go1.22.12
+  # Fixed in: Fixed in: net/http@go1.23.10
+  - id: GO-2025-3751
+    info: https://pkg.go.dev/vuln/GO-2025-3751
+    silence-until: 2025-10-02


### PR DESCRIPTION
## Description
Currently, we only have our custom govulncheck-action enabled on wa, host-operator, member-operator, and registration-service. We need to enable it in the other repos (toolchain-e2e, toolchain-common, ...)

### Why are we using our custom `toolchain-cicd/govulncheck-action`?
Unfortunately, govulncheck does not have a feature for ignoring the vulns. There is a [feature request](https://github.com/golang/go/issues/59507), but we do not know when it will be addressed. To avoid govulncheck failing in PRs, we implemented a workaround on toolchain-cicd to ignore vulnerabilities that do not have a fix available or require a higher Go version than we have.

## Related PRs
https://github.com/codeready-toolchain/toolchain-e2e/pull/1190
https://github.com/codeready-toolchain/toolchain-common/pull/490
https://github.com/codeready-toolchain/api/pull/483

## Issue ticket number and link
[SANDBOX-1401](https://issues.redhat.com/browse/SANDBOX-1401)