### PR TITLE
fix go version in cmd/user-identity-mapper/Dockerfile

### DIFF
--- a/cmd/user-identity-mapper/Dockerfile
+++ b/cmd/user-identity-mapper/Dockerfile
@@ -2,7 +2,7 @@
 # Builder image
 # See https://hub.docker.com/_/golang/
 ################################################################################################
-FROM mirror.gcr.io/golang:1.22 as builder
+FROM mirror.gcr.io/golang:1.23 as builder
 
 ARG OS=linux
 ARG ARCH=amd64


### PR DESCRIPTION
# Description
I forgot to update Go version in `cmd/user-identity-mapper/Dockerfile`, sorry!